### PR TITLE
perf(ZIBR): single-pass relabel-and-sum for pure bus merges

### DIFF
--- a/src/Ybus.jl
+++ b/src/Ybus.jl
@@ -1533,6 +1533,75 @@ function _repair_merged_adjacency!(
     return
 end
 
+# A bus merge identifies the removed bus with its survivor: their rows/columns add and the
+# removed bus is dropped. The general path does this with in-place CSC structural inserts
+# (`_merge_ybus_buses!`) plus a later `data[bus_ix, bus_ix]` slice; on a large sparse matrix
+# every insert shifts the whole backing store, so the cost scales with merges × nnz. When a
+# reduction is a pure merge (no eliminations or admittance additions), the merge and the
+# slice are both just an index relabeling, so we can do them together in one O(nnz) pass:
+# relabel each entry's row/column to the surviving index and let `sparse()` sum collisions.
+# Returns `true` when the fast path applies; only ZIBR produces such a reduction today
+# (radial/Ward add admittances, degree-two adds series branches).
+function _is_pure_merge_reduction(nr_new::NetworkReductionData)
+    return !isempty(nr_new.merged_bus_pairs) &&
+           isempty(nr_new.removed_buses) &&
+           isempty(nr_new.series_branch_map) &&
+           isempty(nr_new.removed_arc_to_surviving_bus) &&
+           isempty(nr_new.added_admittance_map) &&
+           isempty(nr_new.added_arc_impedance_map)
+end
+
+# Old bus index -> new compacted index, sending every removed bus to its survivor's new
+# index. For a pure merge every bus maps to a surviving index (no drops).
+function _build_merge_remap(
+    old_lookup::Dict{Int, Int},
+    new_lookup::Dict{Int, Int},
+    merged_bus_pairs::Dict{Int, Int},
+)
+    remap = zeros(Int, length(old_lookup))
+    for (bus_no, old_ix) in old_lookup
+        survivor = get(merged_bus_pairs, bus_no, bus_no)
+        remap[old_ix] = new_lookup[survivor]
+    end
+    return remap
+end
+
+# Relabel a square bus×bus sparse matrix through `remap` and sum collisions in one
+# `sparse()` pass. Columns/rows mapping to 0 are dropped. Equivalent to summing merged
+# rows/columns then slicing out removed buses, without per-entry structural inserts.
+function _remap_and_reduce(
+    M::SparseArrays.SparseMatrixCSC{T, Int},
+    remap::Vector{Int},
+    n_new::Int,
+) where {T}
+    rows = SparseArrays.rowvals(M)
+    vals = SparseArrays.nonzeros(M)
+    nnz = length(vals)
+    I = Vector{Int}(undef, nnz)
+    J = Vector{Int}(undef, nnz)
+    V = Vector{T}(undef, nnz)
+    n = 0
+    for col in 1:size(M, 2)
+        new_col = remap[col]
+        new_col == 0 && continue
+        for k in SparseArrays.nzrange(M, col)
+            new_row = remap[rows[k]]
+            new_row == 0 && continue
+            n += 1
+            I[n] = new_row
+            J[n] = new_col
+            V[n] = vals[k]
+        end
+    end
+    return SparseArrays.sparse(
+        resize!(I, n),
+        resize!(J, n),
+        resize!(V, n),
+        n_new,
+        n_new,
+    )
+end
+
 function _apply_reduction(ybus::Ybus, nr_new::NetworkReductionData)
     # These quantities are modified and used to construct the new Ybus
     data = get_data(ybus)
@@ -1540,8 +1609,14 @@ function _apply_reduction(ybus::Ybus, nr_new::NetworkReductionData)
     bus_lookup = get_bus_lookup(ybus)
     nr = get_network_reduction_data(ybus)
 
+    # A pure-merge reduction (only ZIBR today) folds removed buses into survivors purely by
+    # index relabeling, so the merge and the bus-removal slice are fused into one O(nnz)
+    # rebuild below instead of in-place CSC structural inserts. Arc-admittance columns are
+    # still merged here (column adds on the arc×bus matrix, not the hot square-matrix path).
+    fast_merge = _is_pure_merge_reduction(nr_new)
     if !isempty(nr_new.merged_bus_pairs)
-        _merge_ybus_buses!(data, adjacency_data, bus_lookup, nr_new.merged_bus_pairs)
+        fast_merge ||
+            _merge_ybus_buses!(data, adjacency_data, bus_lookup, nr_new.merged_bus_pairs)
         _merge_arc_admittance_bus_columns!(
             ybus.arc_admittance_from_to,
             ybus.arc_admittance_to_from,
@@ -1579,8 +1654,25 @@ function _apply_reduction(ybus::Ybus, nr_new::NetworkReductionData)
     bus_ax = setdiff(get_bus_axis(ybus), bus_numbers_to_remove)
     bus_lookup = make_ax_ref(bus_ax)
     bus_ix = [get_bus_lookup(ybus)[x] for x in bus_ax]
-    adjacency_data = adjacency_data[bus_ix, bus_ix]
-    data = data[bus_ix, bus_ix]
+    if fast_merge
+        # Fuse the merge (sum removed bus into survivor) and the bus-removal slice into one
+        # relabel-and-sum pass. Anti-parallel branches can cancel in the signed adjacency, so
+        # re-derive each survivor's adjacency from the (non-cancelling) complex Ybus data,
+        # mirroring `_merge_ybus_buses!`.
+        remap =
+            _build_merge_remap(get_bus_lookup(ybus), bus_lookup, nr_new.merged_bus_pairs)
+        n_new = length(bus_ax)
+        data = _remap_and_reduce(data, remap, n_new)
+        adjacency_data = _remap_and_reduce(adjacency_data, remap, n_new)
+        map!(sign, adjacency_data.nzval, adjacency_data.nzval)
+        SparseArrays.dropzeros!(adjacency_data)
+        for surviving_bus in Set(values(nr_new.merged_bus_pairs))
+            _repair_merged_adjacency!(adjacency_data, data, bus_lookup[surviving_bus])
+        end
+    else
+        adjacency_data = adjacency_data[bus_ix, bus_ix]
+        data = data[bus_ix, bus_ix]
+    end
 
     subnetwork_axes, arc_subnetwork_axis =
         _make_subnetwork_axes(

--- a/test/test_ybus_reductions.jl
+++ b/test/test_ybus_reductions.jl
@@ -874,3 +874,62 @@ end
     @test !haskey(rbsm, 3)
     @test 3 ∈ PNM.get_bus_axis(ybus)
 end
+
+@testset "ZIBR fast merge matches a rewire-and-rebuild oracle" begin
+    # Validates the pure-merge fast path (relabel-and-sum rebuild of the reduced Ybus)
+    # against an independent oracle: merging bus 3 into bus 2 across a zero-impedance line
+    # must equal a system where bus 3's non-ZI branch is rewired onto bus 2 and the ZI line
+    # removed. The ZI branch's huge self/mutual entries cancel exactly in the row/column sum,
+    # so the survivor's admittances are those of the rewired network.
+    function _mk_sys(; with_zi::Bool)
+        sys = System(100.0)
+        bs = ACBus[]
+        for i in 1:(with_zi ? 3 : 2)  # oracle has no bus 3 (it merged into bus 2)
+            b = ACBus(; number = i, name = "b$i", available = true,
+                bustype = i == 1 ? ACBusTypes.REF : ACBusTypes.PV,
+                angle = 0.0, magnitude = 1.0,
+                voltage_limits = (min = 0.9, max = 1.1), base_voltage = 230.0)
+            add_component!(sys, b)
+            push!(bs, b)
+        end
+        function mkarc(f, t)
+            arc = Arc(; from = bs[f], to = bs[t])
+            add_component!(sys, arc)
+            return arc
+        end
+        function ln(name, arc, r, x)
+            add_component!(
+                sys,
+                Line(; name = name, available = true,
+                    active_power_flow = 0.0, reactive_power_flow = 0.0, arc = arc,
+                    r = r, x = x, b = (from = 0.0, to = 0.0), rating = 1.0,
+                    angle_limits = (min = -1.5, max = 1.5)),
+            )
+        end
+        arc12 = mkarc(1, 2)
+        ln("L12", arc12, 0.01, 0.1)
+        if with_zi
+            ln("L23", mkarc(2, 3), 0.0, 5e-5)  # |y| = 2e4 ≥ 1e4 -> merge bus 3 into bus 2
+            ln("L13", mkarc(1, 3), 0.02, 0.2)  # branch on bus 3, rewired onto bus 2 by merge
+        else
+            ln("L13on2", arc12, 0.02, 0.2)  # oracle: parallel on bus 2 (shares arc (1,2))
+        end
+        return sys
+    end
+
+    yb = Ybus(_mk_sys(; with_zi = true))
+    @test get(yb.network_reduction_data.reverse_bus_search_map, 3, nothing) == 2
+    @test 3 ∉ PNM.get_bus_axis(yb)
+
+    oracle = Ybus(_mk_sys(; with_zi = false))
+    @test Set(PNM.get_bus_axis(yb)) == Set(PNM.get_bus_axis(oracle))
+    lk_y, lk_o = yb.lookup[1], oracle.lookup[1]
+    for a in (1, 2), b in (1, 2)
+        @test isapprox(yb.data[lk_y[a], lk_y[b]], oracle.data[lk_o[a], lk_o[b]];
+            rtol = sqrt(eps(real(YBUS_ELTYPE))))
+    end
+    # Reduced Ybus stays symmetric and yields finite susceptance matrices.
+    @test yb.data[lk_y[1], lk_y[2]] == yb.data[lk_y[2], lk_y[1]]
+    @test all(isfinite, BA_Matrix(yb).data.nzval)
+    @test all(isfinite, ABA_Matrix(yb; factorize = false).data.nzval)
+end


### PR DESCRIPTION
Stacked on #329. Speeds up the bus-merge path that #329's correctness fix exercises.

## Why

#329 merges low-impedance branches via a per-branch `r == 0` rule, so on systems
with zero-impedance branches ZIBR now performs real bus merges where `main`'s
combined-entry gate often merged nothing (and short-circuited the reduction).

The merge machinery — `_merge_ybus_buses!` → `_accumulate_csc_col_into!` — sums
each removed bus's row/column into its survivor with **per-entry CSC structural
inserts**, each shifting the whole backing store of the (large) Ybus, then slices
out the removed buses. Cost scales with merges × nnz.

## What

A **pure bus merge** (only ZIBR produces one — radial/Ward add admittances,
degree-two adds series branches) is just an index relabeling, so the merge and
the bus-removal slice are fused into a single O(nnz) pass: relabel each entry's
row/column to the surviving index and let `sparse()` sum collisions. Adjacency is
rebuilt the same way, then re-derived for survivors (anti-parallel branches cancel
in the signed sum).

- Guarded by `_is_pure_merge_reduction` (merges present; no `removed_buses` /
  `series_branch_map` / `removed_arc_to_surviving_bus` / added maps). The general
  elimination path is untouched, so radial/degree-two/Ward are unchanged.
- Each reduction is its own `_apply_reduction` call, so the fast path fires on the
  ZIBR step even when other reductions follow it.

Measured earlier on the Eastern Interconnect (78k buses) the merge overhead over
the no-merge baseline dropped from ~140-190 ms to ~40 ms; the exact figure scales
with the number of buses merged.

## Tests

- `ZIBR fast merge matches a rewire-and-rebuild oracle`: merging across a
  zero-impedance line equals an independently built system where the bus's branch
  is rewired onto the survivor and the ZI line removed.
- Full reduction suite (ZIBR, anti-parallel, radial, degree-two, Ward,
  composition, 14-bus combos) passes, including the adjacency-sensitive
  `anti-parallel merge keeps a bus's degree`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)