### PR TITLE
test: use isapprox for sparsified VirtualPTDF row comparison

### DIFF
--- a/test/test_auto_tolerance.jl
+++ b/test/test_auto_tolerance.jl
@@ -188,7 +188,8 @@ end
     @test count(!iszero, sparse_row) < nnz_dense
     dense_row = v_exact[arc, :]
     for i in eachindex(sparse_row)
-        iszero(sparse_row[i]) || @test sparse_row[i] == dense_row[i]
+        iszero(sparse_row[i]) ||
+            @test isapprox(sparse_row[i], dense_row[i]; rtol = sqrt(eps()))
     end
 end
 


### PR DESCRIPTION
The exact `==` compared two VirtualPTDF solver paths that differ by ~1 ULP, making `test_auto_tolerance.jl:191` flaky; switch to `isapprox`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)