### PR TITLE
Key contingencies by IS id; read the system UUID from PSY

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,12 +23,12 @@ Pardiso = "46dd5b70-b6fb-5a00-ae2d-e8fea33afaf2"
 MKLPardisoExt = "Pardiso"
 
 [sources]
-InfrastructureSystems = {url = "https://github.com/NREL-Sienna/InfrastructureSystems.jl", rev = "IS4"}
-PowerSystems = {url = "https://github.com/NREL-Sienna/PowerSystems.jl", rev = "psy6"}
+InfrastructureSystems = {url = "https://github.com/NREL-Sienna/InfrastructureSystems.jl", rev = "feat/infrastore-integration"}
+PowerSystems = {url = "https://github.com/NREL-Sienna/PowerSystems.jl", rev = "feat/infrastore-integration"}
 # PSY's own [sources] pins for these are ignored once PSY is a dependency rather than the
 # root project; PNM needs its own pins so Pkg can resolve PSY's unregistered OpenAPI deps.
-PowerCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerCoreOpenAPIModels.jl"}
-PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerOperationsOpenAPIModels.jl"}
+PowerCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "feat/infrastore-integration", subdir = "PowerCoreOpenAPIModels.jl"}
+PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "feat/infrastore-integration", subdir = "PowerOperationsOpenAPIModels.jl"}
 
 [compat]
 DataStructures = "^0.19"

--- a/src/PowerNetworkMatrix.jl
+++ b/src/PowerNetworkMatrix.jl
@@ -330,10 +330,10 @@ the UUID of `sys`. No-op when the matrix does not track system origin.
 """
 function _validate_system_uuid(mat::PowerNetworkMatrix, sys::PSY.System)
     mat_uuid = get_system_uuid(mat)
-    if !isnothing(mat_uuid) && mat_uuid != IS.get_uuid(sys)
+    if !isnothing(mat_uuid) && mat_uuid != PSY.get_system_uuid(sys)
         error(
             "System UUID mismatch: the matrix was constructed from a system with " *
-            "UUID $mat_uuid, but the provided system has UUID $(IS.get_uuid(sys)). " *
+            "UUID $mat_uuid, but the provided system has UUID $(PSY.get_system_uuid(sys)). " *
             "Ensure the matrix and system originate from the same source.",
         )
     end

--- a/src/modf_definitions.jl
+++ b/src/modf_definitions.jl
@@ -169,15 +169,15 @@ Base.:(==)(a::NetworkModification, b::NetworkModification) =
     ContingencySpec
 
 A resolved, self-contained contingency specification backed by a
-[`NetworkModification`](@ref). The UUID links back to the source
+[`NetworkModification`](@ref). The id links back to the source
 `PSY.Outage` supplemental attribute for caching purposes.
 
 # Fields
-- `uuid::Base.UUID`: Unique identifier matching the source Outage supplemental attribute.
+- `id::Int`: IS id matching the source Outage supplemental attribute.
 - `modification::NetworkModification`: The network topology change.
 """
 struct ContingencySpec
-    uuid::Base.UUID
+    id::Int
     modification::NetworkModification
 end
 

--- a/src/network_modification.jl
+++ b/src/network_modification.jl
@@ -323,8 +323,8 @@ function NetworkModification(mat::PowerNetworkMatrix, sys::PSY.System, outage::P
               "The outage may only affect non-network components (e.g., generators)."
     end
 
-    outage_uuid = IS.get_uuid(outage)
-    ctg_name = isempty(component_names) ? string(outage_uuid) : join(component_names, "+")
+    outage_id = IS.get_id(outage)
+    ctg_name = isempty(component_names) ? string(outage_id) : join(component_names, "+")
 
     # A fully-outaged ThreeWindingTransformer isolates its star bus and may
     # island a real terminal bus; flag that on `is_islanding`.

--- a/src/populate_cache.jl
+++ b/src/populate_cache.jl
@@ -234,20 +234,20 @@ end
 
 # Resolve a contingency identifier to the `NetworkModification` used as the
 # cache key. Accepts a modification, a `ContingencySpec`, a registered
-# `PSY.Outage`, or a registered outage UUID.
+# `PSY.Outage`, or a registered outage id.
 _resolve_modification(::VirtualMODF, mod::NetworkModification) = mod
 _resolve_modification(::VirtualMODF, ctg::ContingencySpec) = ctg.modification
 function _resolve_modification(vmodf::VirtualMODF, outage::PSY.Outage)
-    return _resolve_modification(vmodf, IS.get_uuid(outage))
+    return _resolve_modification(vmodf, IS.get_id(outage))
 end
-function _resolve_modification(vmodf::VirtualMODF, uuid::Base.UUID)
+function _resolve_modification(vmodf::VirtualMODF, id::Int)
     contingency_cache = get_contingency_cache(vmodf)
-    haskey(contingency_cache, uuid) || error(
-        "Contingency (UUID=$uuid) is not registered. Construct the VirtualMODF " *
+    haskey(contingency_cache, id) || error(
+        "Contingency (id=$id) is not registered. Construct the VirtualMODF " *
         "with the system containing this outage, or pass the NetworkModification " *
         "/ ContingencySpec directly.",
     )
-    return contingency_cache[uuid].modification
+    return contingency_cache[id].modification
 end
 
 # Resolve a monitored arc identifier to its row index. Tuples go through

--- a/src/reduction_helpers.jl
+++ b/src/reduction_helpers.jl
@@ -6,8 +6,8 @@
 function _arc_connecting_two_areas(arc::PSY.Arc)
     from_bus = PSY.get_from(arc)
     to_bus = PSY.get_to(arc)
-    area_from = IS.get_uuid(PSY.get_area(from_bus))
-    area_to = IS.get_uuid(PSY.get_area(to_bus))
+    area_from = IS.get_id(PSY.get_area(from_bus))
+    area_to = IS.get_id(PSY.get_area(to_bus))
     return area_from != area_to
 end
 

--- a/src/virtual_lodf_calculations.jl
+++ b/src/virtual_lodf_calculations.jl
@@ -151,7 +151,7 @@ function VirtualLODF(
         Ymatrix;
         linear_solver = linear_solver,
         tol = tol,
-        system_uuid = IS.get_uuid(sys),
+        system_uuid = PSY.get_system_uuid(sys),
     )
     return VirtualLODF(
         core;

--- a/src/virtual_modf_calculations.jl
+++ b/src/virtual_modf_calculations.jl
@@ -32,7 +32,7 @@ serializes through the process-wide `_LIBKLU_LOCK`.
 - `dist_slack::Vector{Float64}`:
         Distributed slack bus weights (retained for API symmetry; not used by the
         Woodbury kernel).
-- `contingency_cache::Dict{Base.UUID, ContingencySpec}`:
+- `contingency_cache::Dict{Int, ContingencySpec}`:
         Resolved contingencies keyed by outage UUID.
 - `woodbury_cache::Dict{NetworkModification, WoodburyFactors}`:
         Precomputed Woodbury factors keyed by modification.
@@ -45,7 +45,7 @@ struct VirtualMODF{Ax <: NTuple{2, Vector}, L <: NTuple{2, Dict}, K} <:
        PowerNetworkMatrix{Float64}
     core::VirtualFactorCore{Ax, L, K}
     dist_slack::Vector{Float64}
-    contingency_cache::Dict{Base.UUID, ContingencySpec}
+    contingency_cache::Dict{Int, ContingencySpec}
     woodbury_cache::Dict{NetworkModification, WoodburyFactors}
     row_caches::Dict{NetworkModification, RowCache}
     max_cache_size_bytes::Int
@@ -124,7 +124,7 @@ function _apply_woodbury_correction(
 end
 
 """
-    get_registered_contingencies(vmodf::VirtualMODF) -> Dict{Base.UUID, ContingencySpec}
+    get_registered_contingencies(vmodf::VirtualMODF) -> Dict{Int, ContingencySpec}
 
 Return the cached contingency registrations for inspection.
 """
@@ -237,7 +237,7 @@ function VirtualMODF(
         Ymatrix;
         linear_solver = linear_solver,
         tol = tol,
-        system_uuid = IS.get_uuid(sys),
+        system_uuid = PSY.get_system_uuid(sys),
     )
 
     return VirtualMODF(
@@ -267,7 +267,7 @@ function VirtualMODF(
     vmodf = VirtualMODF(
         core,
         dist_slack,
-        Dict{Base.UUID, ContingencySpec}(),
+        Dict{Int, ContingencySpec}(),
         Dict{NetworkModification, WoodburyFactors}(),
         Dict{NetworkModification, RowCache}(),
         max_cache_bytes,
@@ -349,14 +349,14 @@ Delegates to `NetworkModification(mat, sys, outage)` for the resolution logic.
 """
 function _register_outage!(vmodf::VirtualMODF, sys::PSY.System, outage::PSY.Outage)
     contingency_cache = get_contingency_cache(vmodf)
-    outage_uuid = IS.get_uuid(outage)
-    if haskey(contingency_cache, outage_uuid)
-        @warn "Outage with UUID $(outage_uuid) is already registered; skipping."
+    outage_id = IS.get_id(outage)
+    if haskey(contingency_cache, outage_id)
+        @warn "Outage with UUID $(outage_id) is already registered; skipping."
         return
     end
     mod = NetworkModification(vmodf, sys, outage)
-    ctg = ContingencySpec(outage_uuid, mod)
-    contingency_cache[outage_uuid] = ctg
+    ctg = ContingencySpec(outage_id, mod)
+    contingency_cache[outage_id] = ctg
     _warn_if_transmission_dropped(sys, outage, mod)
     return
 end
@@ -470,7 +470,7 @@ function Base.getindex(
     return vmodf[monitored, contingency.modification]
 end
 
-# --- getindex: by PSY.Outage (UUID lookup → ContingencySpec → NetworkModification) ---
+# --- getindex: by PSY.Outage (id lookup → ContingencySpec → NetworkModification) ---
 
 """
 Get the post-contingency PTDF row for monitored arc `monitored` when outage `outage` trips.
@@ -481,17 +481,17 @@ $(TYPEDSIGNATURES)
 function Base.getindex(vmodf::VirtualMODF, monitored::Int, outage::PSY.Outage)
     core = get_core(vmodf)
     contingency_cache = get_contingency_cache(vmodf)
-    outage_uuid = IS.get_uuid(outage)
+    outage_id = IS.get_id(outage)
     # Pair with the locked `empty!` in `clear_all_caches!`; without it, a
     # concurrent clear could rehash `contingency_cache` mid-lookup.
     ctg = @lock core.solver_lock begin
-        if !haskey(contingency_cache, outage_uuid)
+        if !haskey(contingency_cache, outage_id)
             error(
-                "Outage (UUID=$outage_uuid) is not registered. " *
+                "Outage (UUID=$outage_id) is not registered. " *
                 "Construct VirtualMODF with the system containing this outage.",
             )
         end
-        contingency_cache[outage_uuid]
+        contingency_cache[outage_id]
     end
     return vmodf[monitored, ctg.modification]
 end

--- a/src/virtual_ptdf_calculations.jl
+++ b/src/virtual_ptdf_calculations.jl
@@ -167,7 +167,7 @@ function VirtualPTDF(
         tol = tol,
         max_cache_size = max_cache_size,
         persistent_arcs = persistent_arcs,
-        system_uuid = IS.get_uuid(sys),
+        system_uuid = PSY.get_system_uuid(sys),
     )
 end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -24,17 +24,17 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimeSeries = "9e3dc215-6440-5c97-bce1-76c03772f85e"
 
 [sources]
-InfrastructureSystems = {rev = "IS4", url = "https://github.com/NREL-Sienna/InfrastructureSystems.jl"}
-PowerFlowFileParser = {rev = "psy6", url = "https://github.com/NREL-Sienna/PowerFlowFileParser.jl"}
-PowerSystemCaseBuilder = {rev = "psy6", url = "https://github.com/NREL-Sienna/PowerSystemCaseBuilder.jl"}
-PowerSystems = {rev = "psy6", url = "https://github.com/NREL-Sienna/PowerSystems.jl"}
+InfrastructureSystems = {rev = "feat/infrastore-integration", url = "https://github.com/NREL-Sienna/InfrastructureSystems.jl"}
+PowerFlowFileParser = {rev = "feat/infrastore-integration", url = "https://github.com/NREL-Sienna/PowerFlowFileParser.jl"}
+PowerSystemCaseBuilder = {rev = "feat/infrastore-integration", url = "https://github.com/NREL-Sienna/PowerSystemCaseBuilder.jl"}
+PowerSystems = {rev = "feat/infrastore-integration", url = "https://github.com/NREL-Sienna/PowerSystems.jl"}
 # PSY's own [sources] pins for these are ignored once PSY is a dependency rather than the
 # root project; the test env needs its own pins so Pkg can resolve PSY's unregistered OpenAPI deps.
-PowerCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerCoreOpenAPIModels.jl"}
-PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerOperationsOpenAPIModels.jl"}
+PowerCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "feat/infrastore-integration", subdir = "PowerCoreOpenAPIModels.jl"}
+PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "feat/infrastore-integration", subdir = "PowerOperationsOpenAPIModels.jl"}
 # PSCB's own [sources] pin for this is ignored once PSCB is a dependency rather than the root
 # project; the test env needs its own pin so Pkg can resolve PSCB's unregistered parser dep.
-PowerTableDataParser = {url = "https://github.com/NLR-Sienna/PowerTableDataParser.jl.git", rev = "psy6"}
+PowerTableDataParser = {url = "https://github.com/NLR-Sienna/PowerTableDataParser.jl.git", rev = "feat/infrastore-integration"}
 
 [compat]
 julia = "^1.10"

--- a/test/test_modf_islanding.jl
+++ b/test/test_modf_islanding.jl
@@ -76,10 +76,10 @@ end
     @testset "M=1 single bridge arc" begin
         b = vmodf.arc_susceptances[e_bridge1]
         ctg = ContingencySpec(
-            Base.UUID(UInt128(50001)),
+            50001,
             NetworkModification("island_m1", [ArcModification(e_bridge1, -b)]),
         )
-        vmodf.contingency_cache[ctg.uuid] = ctg
+        vmodf.contingency_cache[ctg.id] = ctg
 
         row = PNM._compute_modf_entry(vmodf, monitored, ctg.modification)
         @test all(isfinite, row)
@@ -101,13 +101,13 @@ end
         b_br = vmodf.arc_susceptances[e_bridge1]
         b_ot = vmodf.arc_susceptances[e_other]
         ctg = ContingencySpec(
-            Base.UUID(UInt128(50002)),
+            50002,
             NetworkModification(
                 "island_m2",
                 [ArcModification(e_bridge1, -b_br), ArcModification(e_other, -b_ot)],
             ),
         )
-        vmodf.contingency_cache[ctg.uuid] = ctg
+        vmodf.contingency_cache[ctg.id] = ctg
 
         row = PNM._compute_modf_entry(vmodf, monitored, ctg.modification)
         @test !all(x -> abs(x) < 1e-10, row)
@@ -120,13 +120,13 @@ end
         b1 = vmodf.arc_susceptances[e_bridge1]
         b2 = vmodf.arc_susceptances[e_bridge2]
         ctg = ContingencySpec(
-            Base.UUID(UInt128(50003)),
+            50003,
             NetworkModification(
                 "island_2bridge",
                 [ArcModification(e_bridge1, -b1), ArcModification(e_bridge2, -b2)],
             ),
         )
-        vmodf.contingency_cache[ctg.uuid] = ctg
+        vmodf.contingency_cache[ctg.id] = ctg
 
         row = PNM._compute_modf_entry(vmodf, monitored, ctg.modification)
         @test all(isfinite, row)
@@ -144,7 +144,7 @@ end
         b2 = vmodf.arc_susceptances[e_bridge2]
         b3 = vmodf.arc_susceptances[e_other]
         ctg = ContingencySpec(
-            Base.UUID(UInt128(50004)),
+            50004,
             NetworkModification(
                 "island_m3",
                 [
@@ -154,7 +154,7 @@ end
                 ],
             ),
         )
-        vmodf.contingency_cache[ctg.uuid] = ctg
+        vmodf.contingency_cache[ctg.id] = ctg
 
         row = PNM._compute_modf_entry(vmodf, monitored, ctg.modification)
         @test !all(x -> abs(x) < 1e-10, row)
@@ -178,12 +178,12 @@ end
 
     for e in 1:n_arcs
         b_e = vmodf.arc_susceptances[e]
-        ctg_uuid = Base.UUID(UInt128(60000 + e))
+        ctg_id = 60000 + e
         ctg = ContingencySpec(
-            ctg_uuid,
+            ctg_id,
             NetworkModification("regression_$e", [ArcModification(e, -b_e)]),
         )
-        vmodf.contingency_cache[ctg_uuid] = ctg
+        vmodf.contingency_cache[ctg_id] = ctg
 
         for m in 1:n_arcs
             modf_row = PNM._compute_modf_entry(vmodf, m, ctg.modification)

--- a/test/test_modf_lodf_reductions.jl
+++ b/test/test_modf_lodf_reductions.jl
@@ -85,12 +85,12 @@ function verify_modf_lodf_identity(
     b_arc = vmodf.arc_susceptances[arc_idx]
 
     # Build and register ContingencySpec
-    ctg_uuid = Base.UUID(UInt128(hash((arc_idx, delta_b))))
+    ctg_id = Int(hash((arc_idx, delta_b)) & 0x7fffffffffffffff)
     ctg = ContingencySpec(
-        ctg_uuid,
+        ctg_id,
         NetworkModification("test_arc_$(arc_idx)", [ArcModification(arc_idx, delta_b)]),
     )
-    vmodf.contingency_cache[ctg_uuid] = ctg
+    vmodf.contingency_cache[ctg_id] = ctg
 
     # LODF reference: standard column for full outage, partial otherwise
     is_full_outage = isapprox(delta_b, -b_arc; atol = 1e-12)
@@ -156,15 +156,15 @@ function verify_modf_n2_lodf_identity(
             "Arc pair ($arc_idx1, $arc_idx2) is an N-2 islanding pair (denom=$denom); use a non-islanding pair",
         )
 
-    ctg_uuid = Base.UUID(UInt128(hash((arc_idx1, arc_idx2, :n2))))
+    ctg_id = Int(hash((arc_idx1, arc_idx2, :n2)) & 0x7fffffffffffffff)
     ctg = ContingencySpec(
-        ctg_uuid,
+        ctg_id,
         NetworkModification(
             "n2_test_$(arc_idx1)_$(arc_idx2)",
             [ArcModification(arc_idx1, -b_arc1), ArcModification(arc_idx2, -b_arc2)],
         ),
     )
-    vmodf.contingency_cache[ctg_uuid] = ctg
+    vmodf.contingency_cache[ctg_id] = ctg
 
     for m in 1:n_arcs
         Lm1 = vlodf[m, arc_idx1]
@@ -389,9 +389,9 @@ end
         )
         n2_mod = NetworkModification("n2_parallel_xfmr_plus_line", n2_mods)
 
-        ctg_uuid = Base.UUID(UInt128(515151))
-        ctg = ContingencySpec(ctg_uuid, n2_mod)
-        vmodf.contingency_cache[ctg_uuid] = ctg
+        ctg_id = 515151
+        ctg = ContingencySpec(ctg_id, n2_mod)
+        vmodf.contingency_cache[ctg_id] = ctg
 
         sys_post = deepcopy(sys)
         PSY.remove_component!(
@@ -451,9 +451,9 @@ end
         )
         n3_mod = NetworkModification("n3_parallel_xfmr_plus_two_lines", n3_mods)
 
-        ctg_uuid = Base.UUID(UInt128(515251))
-        ctg = ContingencySpec(ctg_uuid, n3_mod)
-        vmodf.contingency_cache[ctg_uuid] = ctg
+        ctg_id = 515251
+        ctg = ContingencySpec(ctg_id, n3_mod)
+        vmodf.contingency_cache[ctg_id] = ctg
 
         sys_post = deepcopy(sys)
         PSY.remove_component!(
@@ -518,9 +518,9 @@ end
         )
         n3_mod = NetworkModification("n3_three_regular_lines", n3_mods)
 
-        ctg_uuid = Base.UUID(UInt128(515252))
-        ctg = ContingencySpec(ctg_uuid, n3_mod)
-        vmodf.contingency_cache[ctg_uuid] = ctg
+        ctg_id = 515252
+        ctg = ContingencySpec(ctg_id, n3_mod)
+        vmodf.contingency_cache[ctg_id] = ctg
 
         sys_post = deepcopy(sys)
         PSY.remove_component!(sys_post, PSY.get_component(PSY.Line, sys_post, "A23"))

--- a/test/test_modf_reduction_consistency.jl
+++ b/test/test_modf_reduction_consistency.jl
@@ -34,7 +34,7 @@ function _branch_on_arcs(sys, nrd, arcs)
     return nothing
 end
 
-_fixed_outage(; monitored = Base.UUID[]) =
+_fixed_outage(; monitored = Int[]) =
     PSY.FixedForcedOutage(; outage_status = 0.0, monitored_components = monitored)
 
 function _arc_buses(branch)
@@ -166,7 +166,7 @@ end
     @test haskey(arc_lookup, (fb, tb)) || haskey(arc_lookup, (tb, fb))
 
     outage = PSY.get_supplemental_attributes(target)[1]
-    ctg = get_registered_contingencies(protected_modf)[IS.get_uuid(outage)]
+    ctg = get_registered_contingencies(protected_modf)[IS.get_id(outage)]
     @test !isempty(ctg.modification.arc_modifications)
 end
 
@@ -306,10 +306,10 @@ end
     e = 1
     b_e = base.arc_susceptances[e]
     ctg = ContingencySpec(
-        Base.UUID(UInt128(123456)),
+        123456,
         NetworkModification("ctg", [ArcModification(e, -b_e)]),
     )
-    base.contingency_cache[ctg.uuid] = ctg
+    base.contingency_cache[ctg.id] = ctg
 
     err = try
         base[missing_arc, ctg]
@@ -357,7 +357,7 @@ end
     @test haskey(arc_lookup, (fb, tb)) || haskey(arc_lookup, (tb, fb))
 
     outage = PSY.get_supplemental_attributes(external)[1]
-    ctg = get_registered_contingencies(vmodf)[IS.get_uuid(outage)]
+    ctg = get_registered_contingencies(vmodf)[IS.get_id(outage)]
     @test !isempty(ctg.modification.arc_modifications)
 end
 
@@ -390,7 +390,7 @@ end
     tfb, ttb = _arc_buses(target)
     target_arc = haskey(PNM.get_arc_lookup(reduced), (tfb, ttb)) ? (tfb, ttb) : (ttb, tfb)
     @test haskey(PNM.get_arc_lookup(reduced), target_arc)
-    target_uuid = IS.get_uuid(PSY.get_supplemental_attributes(target)[1])
+    target_id = IS.get_id(PSY.get_supplemental_attributes(target)[1])
 
     bus_lookup_full = PNM.get_bus_lookup(full)
     nrd_full = full.network_reduction_data
@@ -404,11 +404,11 @@ end
     tested_target = false
     for br in candidate
         outage = PSY.get_supplemental_attributes(br)[1]
-        uuid = IS.get_uuid(outage)
-        haskey(get_registered_contingencies(full), uuid) || continue
-        haskey(get_registered_contingencies(reduced), uuid) || continue
-        ctg_full = get_registered_contingencies(full)[uuid]
-        ctg_red = get_registered_contingencies(reduced)[uuid]
+        id = IS.get_id(outage)
+        haskey(get_registered_contingencies(full), id) || continue
+        haskey(get_registered_contingencies(reduced), id) || continue
+        ctg_full = get_registered_contingencies(full)[id]
+        ctg_red = get_registered_contingencies(reduced)[id]
         for arc in arcs_to_compare
             haskey(PNM.get_arc_lookup(full), arc) || continue
             ix_full = PNM.get_arc_lookup(full)[arc]
@@ -420,7 +420,7 @@ end
                 ib_red = PNM.get_bus_index(bus, bus_lookup_red, nrd_red)
                 @test isapprox(row_red[ib_red], row_full[ib_full]; atol = 1e-6)
                 tested_any = true
-                uuid == target_uuid && (tested_target = true)
+                id == target_id && (tested_target = true)
             end
         end
     end

--- a/test/test_network_modification.jl
+++ b/test/test_network_modification.jl
@@ -167,12 +167,12 @@ end
 
     for e in 1:n_arcs
         b_e = vptdf.arc_susceptances[e]
-        ctg_uuid = Base.UUID(UInt128(e + 10000))
+        ctg_id = e + 10000
         ctg = ContingencySpec(
-            ctg_uuid,
+            ctg_id,
             NetworkModification("test_$e", [ArcModification(e, -b_e)]),
         )
-        vmodf.contingency_cache[ctg_uuid] = ctg
+        vmodf.contingency_cache[ctg_id] = ctg
 
         mod = NetworkModification(ctg)
         wf = compute_woodbury_factors(vptdf, mod)

--- a/test/test_populate_cache.jl
+++ b/test/test_populate_cache.jl
@@ -93,7 +93,7 @@ end
     ctgs = ContingencySpec[]
     for e in 1:3
         b_e = PNM._get_arc_susceptances(v_pop)[e]
-        uuid = Base.UUID(UInt128(7000 + e))
+        uuid = 7000 + e
         ctg = ContingencySpec(
             uuid,
             NetworkModification("populate_ctg_$e", [ArcModification(e, -b_e)]),
@@ -124,7 +124,7 @@ end
 
     e = 1
     b_e = PNM._get_arc_susceptances(vmodf)[e]
-    uuid = Base.UUID(UInt128(7100))
+    uuid = 7100
     ctg = ContingencySpec(
         uuid,
         NetworkModification("populate_tuple_ctg", [ArcModification(e, -b_e)]),
@@ -140,7 +140,7 @@ end
     # Unregistered UUID must error clearly
     @test_throws ErrorException populate_cache(
         vmodf,
-        [Base.UUID(UInt128(99999))];
+        [99999];
         monitored = [1],
     )
 end
@@ -175,7 +175,7 @@ end
     # MODF on the shared core: register one contingency in both and populate.
     e = 1
     b_e = PNM._get_arc_susceptances(vmodf)[e]
-    uuid = Base.UUID(UInt128(7300))
+    uuid = 7300
     ctg = ContingencySpec(
         uuid,
         NetworkModification("shared_core_ctg", [ArcModification(e, -b_e)]),

--- a/test/test_system_uuid_tracking.jl
+++ b/test/test_system_uuid_tracking.jl
@@ -1,6 +1,6 @@
 @testset "System UUID tracking in VirtualPTDF" begin
     sys = PSB.build_system(PSB.PSITestSystems, "c_sys5")
-    sys_uuid = IS.get_uuid(sys)
+    sys_uuid = PSY.get_system_uuid(sys)
 
     # UUID is stored when constructing from system
     vptdf = VirtualPTDF(sys)
@@ -14,7 +14,7 @@ end
 
 @testset "System UUID tracking in VirtualMODF" begin
     sys = PSB.build_system(PSB.PSITestSystems, "c_sys5")
-    sys_uuid = IS.get_uuid(sys)
+    sys_uuid = PSY.get_system_uuid(sys)
 
     vmodf = VirtualMODF(sys)
     @test get_system_uuid(vmodf) == sys_uuid

--- a/test/test_virtual_modf.jl
+++ b/test/test_virtual_modf.jl
@@ -26,12 +26,12 @@ end
 
     for e in 1:n_arcs
         b_e = vmodf.arc_susceptances[e]
-        ctg_uuid = Base.UUID(UInt128(e))
+        ctg_id = e
         ctg = ContingencySpec(
-            ctg_uuid,
+            ctg_id,
             NetworkModification("outage_arc_$e", [ArcModification(e, -b_e)]),
         )
-        vmodf.contingency_cache[ctg_uuid] = ctg
+        vmodf.contingency_cache[ctg_id] = ctg
 
         for m in 1:n_arcs
             # Post-contingency PTDF from VirtualMODF
@@ -53,12 +53,12 @@ end
     # Register a manual contingency
     e = 1
     b_e = vmodf.arc_susceptances[e]
-    ctg_uuid = Base.UUID(UInt128(999))
+    ctg_id = 999
     ctg = ContingencySpec(
-        ctg_uuid,
+        ctg_id,
         NetworkModification("test_outage", [ArcModification(e, -b_e)]),
     )
-    vmodf.contingency_cache[ctg_uuid] = ctg
+    vmodf.contingency_cache[ctg_id] = ctg
 
     # Query by integer monitored index + ContingencySpec
     # Row length equals the number of buses in VirtualMODF's bus axis (non-reference buses)
@@ -82,12 +82,12 @@ end
 
     e = 1
     b_e = vmodf.arc_susceptances[e]
-    ctg_uuid = Base.UUID(UInt128(998))
+    ctg_id = 998
     ctg = ContingencySpec(
-        ctg_uuid,
+        ctg_id,
         NetworkModification("test_outage_tuple", [ArcModification(e, -b_e)]),
     )
-    vmodf.contingency_cache[ctg_uuid] = ctg
+    vmodf.contingency_cache[ctg_id] = ctg
 
     # Query using arc tuple
     arc_tuple = vmodf.axes[1][1]
@@ -111,12 +111,12 @@ end
     # Register a contingency and compute a row
     e = 1
     b_e = vmodf.arc_susceptances[e]
-    ctg_uuid = Base.UUID(UInt128(500))
+    ctg_id = 500
     ctg = ContingencySpec(
-        ctg_uuid,
+        ctg_id,
         NetworkModification("cache_test", [ArcModification(e, -b_e)]),
     )
-    vmodf.contingency_cache[ctg_uuid] = ctg
+    vmodf.contingency_cache[ctg_id] = ctg
 
     _ = vmodf[1, ctg]  # Triggers computation + caching
 
@@ -150,7 +150,7 @@ end
     # Test show on non-empty vmodf (register a contingency)
     e = 1
     b_e = vmodf.arc_susceptances[e]
-    ctg_uuid_show = Base.UUID(UInt128(9999))
+    ctg_uuid_show = 9999
     ctg_show = ContingencySpec(
         ctg_uuid_show,
         NetworkModification("show_test", [ArcModification(e, -b_e)]),
@@ -183,12 +183,12 @@ end
     # Register a single-arc full outage
     e = 1
     b_e = vmodf.arc_susceptances[e]
-    ctg_uuid = Base.UUID(UInt128(8888))
+    ctg_id = 8888
     ctg = ContingencySpec(
-        ctg_uuid,
+        ctg_id,
         NetworkModification("public_api_test", [ArcModification(e, -b_e)]),
     )
-    vmodf.contingency_cache[ctg_uuid] = ctg
+    vmodf.contingency_cache[ctg_id] = ctg
 
     # Verify all monitored arcs through the public getindex API
     for m in 1:n_arcs
@@ -210,12 +210,12 @@ end
 
     e = 1
     b_e = vmodf.arc_susceptances[e]
-    ctg_uuid = Base.UUID(UInt128(700))
+    ctg_id = 700
     ctg = ContingencySpec(
-        ctg_uuid,
+        ctg_id,
         NetworkModification("reuse_test", [ArcModification(e, -b_e)]),
     )
-    vmodf.contingency_cache[ctg_uuid] = ctg
+    vmodf.contingency_cache[ctg_id] = ctg
 
     # First query: computes Woodbury factors + row
     row1 = vmodf[1, ctg]
@@ -264,12 +264,12 @@ end
     buses_to_compare = collect(keys(nrd_d2.bus_reduction_map))
     for branch in valid_outage_branches
         outage = get_supplemental_attributes(branch)[1]
-        ctg_uuid = outage.internal.uuid
+        ctg_id = IS.get_id(outage)
         # Skip branches not registered as contingencies in either system
-        haskey(get_registered_contingencies(vmodf), ctg_uuid) || continue
-        haskey(get_registered_contingencies(vmodf_d2), ctg_uuid) || continue
-        ctg = get_registered_contingencies(vmodf)[ctg_uuid]
-        ctg_d2 = get_registered_contingencies(vmodf_d2)[ctg_uuid]
+        haskey(get_registered_contingencies(vmodf), ctg_id) || continue
+        haskey(get_registered_contingencies(vmodf_d2), ctg_id) || continue
+        ctg = get_registered_contingencies(vmodf)[ctg_id]
+        ctg_d2 = get_registered_contingencies(vmodf_d2)[ctg_id]
         for arc in arcs_to_compare
             ix_arc = PNM.get_arc_lookup(vmodf)[arc]
             ix_arc_d2 = PNM.get_arc_lookup(vmodf_d2)[arc]
@@ -335,12 +335,12 @@ end
     for e in 1:n_arcs
         e == flip_arc && continue
         b_e = vmodf.arc_susceptances[e]
-        ctg_uuid = Base.UUID(UInt128(30000 + e))
+        ctg_id = 30000 + e
         ctg = ContingencySpec(
-            ctg_uuid,
+            ctg_id,
             NetworkModification("sign_ctg_$e", [ArcModification(e, -b_e)]),
         )
-        vmodf.contingency_cache[ctg_uuid] = ctg
+        vmodf.contingency_cache[ctg_id] = ctg
 
         modf_row = PNM._compute_modf_entry(vmodf, flip_arc, ctg.modification)
         expected = ptdf_ref[flip_arc, :] .+ vlodf[flip_arc, e] .* ptdf_ref[e, :]
@@ -363,8 +363,8 @@ end
     for branch in get_components(ACTransmission, sys)
         !has_supplemental_attributes(branch) && continue
         outage = get_supplemental_attributes(branch)[1]
-        ctg_uuid = outage.internal.uuid
-        ctg = get_registered_contingencies(vmodf)[ctg_uuid]
+        ctg_id = IS.get_id(outage)
+        ctg = get_registered_contingencies(vmodf)[ctg_id]
         @test ctg.modification.arc_modifications[1].delta_b <= 0.0
     end
 end
@@ -533,7 +533,7 @@ end
     # LODF formula is undefined; skip those pairs.
     n2_is_islanding(e1, e2) = abs(1 - vlodf[e1, e2] * vlodf[e2, e1]) < 1e-6
 
-    uuid_counter = UInt128(10_000)
+    ctg_counter = 10_000
     for e1 in 1:n_arcs
         is_bridge(e1) && continue
         for e2 in (e1 + 1):n_arcs
@@ -543,16 +543,16 @@ end
             b_e1 = vmodf.arc_susceptances[e1]
             b_e2 = vmodf.arc_susceptances[e2]
 
-            ctg_uuid = Base.UUID(uuid_counter)
-            uuid_counter += 1
+            ctg_id = ctg_counter
+            ctg_counter += 1
             ctg = ContingencySpec(
-                ctg_uuid,
+                ctg_id,
                 NetworkModification(
                     "n2_outage_$(e1)_$(e2)",
                     [ArcModification(e1, -b_e1), ArcModification(e2, -b_e2)],
                 ),
             )
-            vmodf.contingency_cache[ctg_uuid] = ctg
+            vmodf.contingency_cache[ctg_id] = ctg
 
             for m in 1:n_arcs
                 modf_row = PNM._compute_modf_entry(vmodf, m, ctg.modification)
@@ -623,15 +623,15 @@ end
 
     b_e1 = vmodf.arc_susceptances[e1]
     b_e2 = vmodf.arc_susceptances[e2]
-    ctg_uuid = Base.UUID(UInt128(88_000))
+    ctg_id = 88_000
     ctg = ContingencySpec(
-        ctg_uuid,
+        ctg_id,
         NetworkModification(
             "n2_island_B34_B30",
             [ArcModification(e1, -b_e1), ArcModification(e2, -b_e2)],
         ),
     )
-    vmodf.contingency_cache[ctg_uuid] = ctg
+    vmodf.contingency_cache[ctg_id] = ctg
 
     # Rebuild the PTDF with both lines disabled — gold-standard ground truth.
     sys_mod = PSB.build_system(PSB.PSITestSystems, "test_RTS_GMLC_sys")
@@ -702,11 +702,11 @@ end
     # Register the same N-1 contingency on both and compare one MODF row.
     e = 1
     b_e = vmodf_klu.arc_susceptances[e]
-    ctg_uuid = Base.UUID(UInt128(424242))
+    ctg_id = 424242
     mod = NetworkModification("aa_parity_outage", [ArcModification(e, -b_e)])
-    ctg = ContingencySpec(ctg_uuid, mod)
-    vmodf_klu.contingency_cache[ctg_uuid] = ctg
-    vmodf_aa.contingency_cache[ctg_uuid] = ctg
+    ctg = ContingencySpec(ctg_id, mod)
+    vmodf_klu.contingency_cache[ctg_id] = ctg
+    vmodf_aa.contingency_cache[ctg_id] = ctg
 
     row_klu = vmodf_klu[2, ctg]
     row_aa = vmodf_aa[2, ctg]
@@ -720,10 +720,10 @@ end
     # Moving sparsification ahead of the solve would amplify it by ||W_inv|| (~190x).
     sys = PSB.build_system(PSB.PSITestSystems, "c_sys14")
 
-    function _register_ctg!(v, arcs, uuidint)
+    function _register_ctg!(v, arcs, ctgint)
         mods = [ArcModification(e, -v.arc_susceptances[e]) for e in arcs]
-        u = Base.UUID(UInt128(uuidint))
-        ctg = ContingencySpec(u, NetworkModification("r2_$(uuidint)", mods))
+        u = ctgint
+        ctg = ContingencySpec(u, NetworkModification("r2_$(ctgint)", mods))
         v.contingency_cache[u] = ctg
         return ctg
     end


### PR DESCRIPTION
`IS.get_uuid` no longer exists. Components and supplemental attributes are identified by an integer IS id, and the System's UUID is the only one left — reachable as `PSY.get_system_uuid`.

So `ContingencySpec` identifies its source outage by `id::Int` rather than `uuid::Base.UUID`, and the contingency caches keyed by it become `Dict{Int, ContingencySpec}`. Area identity in the reduction helpers and outage lookups in `populate_cache`/`virtual_modf_calculations` move to `IS.get_id`. The system-UUID tracking in `PowerNetworkMatrix` and the virtual factor calculations reads `PSY.get_system_uuid(sys)`; `system_uuid` stays a `Base.UUID` because it still is one.

The tests carried the bulk of the change: they minted synthetic contingency keys as `Base.UUID(UInt128(n))`, which are now plain integers. The two derived from `hash` are masked into the positive `Int` range, since `hash` returns a `UInt64` that does not fit. `_fixed_outage`'s `monitored` keyword takes `Int[]`, matching PSY's `monitored_components::Set{Int}`.

