### PR TITLE
Resolve nested reduction aggregates through one leaf walk

### DIFF
--- a/src/BranchCatalog.jl
+++ b/src/BranchCatalog.jl
@@ -210,20 +210,68 @@ function _build_component_name_index(nrd::NetworkReductionData, predicate)
 end
 
 """
-    BranchCatalog(nrd::NetworkReductionData)
+Throws unless every arc the reduction *folded* is still reachable by component type. Opt-in:
+pass `validate = true` to [`BranchCatalog`](@ref), or call this directly on a catalog under
+test. Construction does not run it by default.
 
-The complete index over `nrd`.
+Radial reduction legitimately removes a branch: its arc leaves the network and leaves these
+maps, so there is nothing left to index. Series and parallel reductions remove nothing --
+they fold branches into a composite arc that still exists and still carries flow, so it must
+stay reachable. This checks that the distinction held.
+
+The two are indistinguishable to a consumer, which is why the check is worth writing: an arc
+is reached only by asking for a PSY component type, and a type that indexes nothing returns
+an empty map rather than an error. A folded arc that lost its entry is therefore invisible --
+no flow variable, no rating constraint, no nodal-balance term, and no complaint.
 """
-BranchCatalog(nrd::NetworkReductionData) = BranchCatalog(nrd, _keep_all)
+function _validate_catalog_closure(nrd::NetworkReductionData, name_to_arc::NAME_TO_ARC)
+    indexed = Set{Tuple{Int, Int}}()
+    for by_name in values(name_to_arc)
+        for (arc, _) in values(by_name)
+            push!(indexed, arc)
+        end
+    end
+    # Only the component-backed maps. Ward's `added_arc_impedance_map` arcs come out of
+    # Gaussian elimination and are backed by no component, so no component type can claim
+    # them; they are outside this invariant by construction.
+    for (map_name, source) in (
+        (:direct_branch_map, nrd.direct_branch_map),
+        (:parallel_branch_map, nrd.parallel_branch_map),
+        (:series_branch_map, nrd.series_branch_map),
+    )
+        for (arc, entry) in source
+            arc in indexed && continue
+            error(
+                "Arc $arc ($(get_name(entry)) in $map_name) is reachable from no branch " *
+                "type in the catalog, so nothing that indexes by component type can find " *
+                "it. Leaf types: $(_get_concrete_types(entry)).",
+            )
+        end
+    end
+    return
+end
 
 """
-    BranchCatalog(nrd::NetworkReductionData, predicate)
+    BranchCatalog(nrd::NetworkReductionData; validate = false)
+
+The complete index over `nrd`. See `validate` on the filtered method below.
+"""
+BranchCatalog(nrd::NetworkReductionData; validate::Bool = false) =
+    BranchCatalog(nrd, _keep_all; validate = validate)
+
+"""
+    BranchCatalog(nrd::NetworkReductionData, predicate; validate = false)
 
 Index over `nrd` holding only entries `predicate` accepts, where `predicate(T, component)`
 returns whether a component of branch type `T` should be indexed. An aggregate is judged by
-`_entry_matches`, which applies the predicate to its members.
+`_entry_matches`, which applies the predicate to every physical branch at its leaves.
+
+`validate` runs [`_validate_catalog_closure`](@ref) before returning. It is off by default so
+that indexing stays a pure build step; turn it on in tests, or wherever a caller wants the
+folded-arc invariant enforced rather than assumed. It is rejected for a filtered catalog,
+where the invariant does not hold by design.
 """
-function BranchCatalog(nrd::NetworkReductionData, predicate)
+function BranchCatalog(nrd::NetworkReductionData, predicate; validate::Bool = false)
     maps = BranchMapsByType()
     name_to_arc = NAME_TO_ARC()
     component_to_entry = COMPONENT_TO_ENTRY()
@@ -257,6 +305,19 @@ function BranchCatalog(nrd::NetworkReductionData, predicate)
     _index_reverse_series!(
         maps.reverse_series_branch_map, nrd.reverse_series_branch_map, predicate,
     )
+
+    if validate
+        # Refused rather than skipped: a filter drops arcs by design, so an unreachable arc
+        # there is a filter decision, not a lost entry. Silently answering "valid" would
+        # report a guarantee this cannot give.
+        _is_unfiltered(predicate) || throw(
+            ArgumentError(
+                "validate = true applies only to an unfiltered catalog; a filtered one \
+                 omits arcs by design.",
+            ),
+        )
+        _validate_catalog_closure(nrd, name_to_arc)
+    end
 
     return BranchCatalog(
         nrd,

--- a/src/BranchesParallel.jl
+++ b/src/BranchesParallel.jl
@@ -313,19 +313,16 @@ function Base.length(bp::AbstractBranchesParallel)
 end
 
 # Indexed when ANY member is: the arc is modeled, so its group must be reachable.
-_entry_matches(
-    group::BranchesParallel{T},
-    predicate,
-) where {T <: PSY.ACTransmission} = any(predicate(T, device) for device in group)
+# Recursive: consider series-in-parallel.
+_entry_matches(group::BranchesParallel, predicate) =
+    any(_entry_matches(member, predicate) for member in group)
 
-# Indexed only when EVERY member is: a partially-filtered group is not a complete
+# Indexed only when EVERY member is: a partially-filtered mixed group is not a complete
 # representation of its arc.
 function _entry_matches(group::MixedBranchesParallel, predicate)
-    _is_unfiltered(predicate) || _warn_mixed_group("Parallel circuit", group.branches)
-    for branch in group.branches
-        predicate(typeof(branch), branch) || return false
-    end
-    return true
+    _is_unfiltered(predicate) ||
+        _warn_mixed_group("Parallel circuit", _get_segment_components(group))
+    return all(_entry_matches(member, predicate) for member in group)
 end
 
 function Base.:(==)(a::AbstractBranchesParallel, b::AbstractBranchesParallel)

--- a/src/BranchesSeries.jl
+++ b/src/BranchesSeries.jl
@@ -241,22 +241,15 @@ function get_equivalent_emergency_rating(branch::PSY.GenericArcImpedance)
     return PSY.get_max_flow(branch, PSY.DU)
 end
 
-# Indexed only when every segment is: a chain missing one is not a valid representation of
+# Indexed only when EVERY segment is: a chain missing one is not a valid representation of
 # the path between its endpoints.
+# Recursive: might be nested, have BranchesParallel as link in degree 2 chain.
 function _entry_matches(chain::BranchesSeries, predicate)
     if chain.needs_insertion_order && !_is_unfiltered(predicate)
-        _warn_mixed_group("Series circuit", _chain_branches(chain))
+        _warn_mixed_group("Series circuit", _get_segment_components(chain))
     end
-    for (branch_type, branch_list) in chain.branches
-        for device in branch_list
-            predicate(branch_type, device) || return false
-        end
-    end
-    return true
+    return all(_entry_matches(segment, predicate) for segment in chain)
 end
-
-_chain_branches(chain::BranchesSeries) =
-    reduce(vcat, values(chain.branches); init = PSY.ACTransmission[])
 
 function Base.:(==)(a::BranchesSeries, b::BranchesSeries)
     return a.branches == b.branches

--- a/src/NetworkReductionData.jl
+++ b/src/NetworkReductionData.jl
@@ -167,8 +167,19 @@ function get_name(device::T) where {T <: PSY.ACTransmission}
     return PSY.get_name(device)
 end
 
-_get_segment_components(x::T) where {T <: PSY.ACBranch} = [x]
-_get_segment_components(x::AbstractBranchesParallel) = x.branches
+# PERF: profile and optimize.
+# One idea: write specialized methods for depth 2 heterogeneous cases.
+"""
+Every physical branch at the leaves of `entry`, recursing through nested aggregates.
+
+Aggregates nest without a fixed shape, so we walk the full tree, even though depth should
+typically be small: 2, 3, *maybe* 4.
+"""
+leaf_components(branch::PSY.ACTransmission) = (branch,)
+leaf_components(entry::AbstractReductionAggregate) =
+    Iterators.flatten(leaf_components(member) for member in entry)
+
+_get_segment_components(x) = collect(leaf_components(x))
 _get_segment_type(::T) where {T <: PSY.ACBranch} = T
 _get_segment_type(::BranchesParallel{T}) where {T <: PSY.ACTransmission} = T
 _get_segment_type(::MixedBranchesParallel) = MixedBranchesParallel
@@ -176,15 +187,15 @@ _get_segment_type(::MixedBranchesParallel) = MixedBranchesParallel
 # (`PSY.ThreeWindingTransformer`), so 3W entries are looked up by the transformer type.
 _get_segment_type(w::ThreeWindingTransformerCircuit) = get_transformer_type(w)
 
-_get_concrete_types(x::T) where {T <: PSY.ACBranch} = [T]
-_get_concrete_types(::BranchesParallel{T}) where {T <: PSY.ACTransmission} = [T]
-# Bucket keys are always PSY component types, so a group of 3W windings is filed under the
-# parent transformer type. A group can hold windings of transformers of different concrete
-# types, so every distinct parent is returned.
-_get_concrete_types(bp::BranchesParallel{ThreeWindingTransformerCircuit}) =
-    unique(get_transformer_type.(bp.branches))
-# Discoverable under each member's branch type, so per-type iteration finds it.
-_get_concrete_types(bp::MixedBranchesParallel) = unique(_get_segment_type.(bp.branches))
+"""
+The bucket keys an entry is filed under: the type of every physical branch at its leaves, so
+per-type iteration finds every entry that type participates in at any nesting depth.
+
+Bucket keys are always PSY component types -- `_get_segment_type` maps a 3W winding to its
+parent transformer type -- never a PNM aggregate wrapper.
+"""
+_get_concrete_types(entry) =
+    unique(_get_segment_type(leaf) for leaf in leaf_components(entry))
 
 # Construct an empty per-slot dict for `BranchMapsByType.parallel_branch_map`.
 # Value type is `AbstractBranchesParallel` so that the same per-type bucket can

--- a/test/test_nested_reduction_aggregates.jl
+++ b/test/test_nested_reduction_aggregates.jl
@@ -1,0 +1,145 @@
+#=
+Aggregates that contain aggregates.
+
+Two shapes exist and are built deliberately by `get_degree2_reduction`:
+
+  - a parallel group as a chain segment  -- `BranchesSeries` holding a `BranchesParallel`
+  - sibling chains in parallel           -- `BranchesParallel{BranchesSeries}`
+
+`test_2d_reduction.jl` covers the reduction producing them. These tests cover what the
+catalog then does with them: resolving an entry to component types, and folding a filter
+over one. Both have to descend, and both got the nesting wrong by unwrapping a fixed number
+of levels -- which files a group of chains under `BranchesSeries`, a PNM wrapper type that
+no `name_to_arc_map` consumer ever asks for, taking the arc out of the index entirely.
+=#
+
+# Ring core over buses 1-4 plus two three-segment chains between buses 1 and 3, so the
+# composite arc carries a `BranchesParallel{BranchesSeries}`. Lines are named `L_<from>_<to>`.
+function _nested_aggregate_catalog()
+    sys = build_two_parallel_degree_two_chains()
+    ybus = Ybus(sys; network_reductions = NetworkReduction[DegreeTwoReduction()])
+    return sys, get_network_reduction_data(ybus), PNM.get_branch_catalog(ybus)
+end
+
+# The composite arc's orientation depends on interior bus numbering, so match either way.
+_composite_arc(nrd) = only(
+    k for (k, v) in PNM.get_parallel_branch_map(nrd)
+    if all(m isa PNM.BranchesSeries for m in v)
+)
+
+@testset "Nested aggregates resolve to leaf components and leaf types" begin
+    _, nrd, _ = _nested_aggregate_catalog()
+    group = PNM.get_parallel_branch_map(nrd)[_composite_arc(nrd)]
+
+    # The walk descends group -> chain -> line. Unwrapping one level yields the two
+    # `BranchesSeries` members instead of any component.
+    leaves = PNM._get_segment_components(group)
+    @test all(l isa PSY.Line for l in leaves)
+    @test Set(PSY.get_name(l) for l in leaves) ==
+          Set(["L_1_10", "L_10_11", "L_11_3", "L_1_20", "L_20_21", "L_21_3"])
+
+    # Bucket keys are PSY component types, never a PNM aggregate wrapper.
+    @test PNM._get_concrete_types(group) == [PSY.Line]
+    for chain in group
+        @test PNM._get_concrete_types(chain) == [PSY.Line]
+    end
+end
+
+@testset "The composite arc is reachable under its members' component type" begin
+    _, nrd, catalog = _nested_aggregate_catalog()
+    composite = _composite_arc(nrd)
+
+    line_entries = PNM.get_name_to_arc_map(catalog, PSY.Line)
+    arcs = Set(arc for (arc, _) in values(line_entries))
+
+    # `PSY.Line` is the only type any DeviceModel would ask for, so the composite arc has to
+    # be reachable there...
+    @test composite in arcs
+    # ...and must not be filed under a PNM wrapper type instead.
+    @test !haskey(PNM.get_name_to_arc_maps(catalog), PNM.BranchesSeries)
+
+    # Every absorbed member redirects to the entry carrying its flow.
+    redirects = PNM.get_component_to_reduction_name_map(catalog, PSY.Line)
+    entry_names = Set(keys(line_entries))
+    for name in ("L_1_10", "L_10_11", "L_11_3", "L_1_20", "L_20_21", "L_21_3")
+        @test haskey(redirects, name)
+        @test redirects[name] in entry_names
+    end
+end
+
+@testset "Catalog closure holds over nested aggregates" begin
+    _, nrd, catalog = _nested_aggregate_catalog()
+
+    # A degree-two reduction folds; it does not absorb. So every arc must still be reachable
+    # by component type.
+    @test PNM._validate_catalog_closure(nrd, PNM.get_name_to_arc_maps(catalog)) === nothing
+
+    # Same check reached through the opt-in construction path.
+    @test PNM.BranchCatalog(nrd; validate = true) isa PNM.BranchCatalog
+
+    # Refused on a filtered catalog: the invariant does not hold there by design, so
+    # answering "valid" would report a guarantee the check cannot give.
+    @test_throws ArgumentError PNM.BranchCatalog(nrd, (T, c) -> true; validate = true)
+end
+
+@testset "Filters see PSY components, never aggregate wrappers" begin
+    _, nrd, _ = _nested_aggregate_catalog()
+
+    # A filter is written against PSY components. Handing it a `BranchesSeries` -- which has
+    # no `PSY.get_arc` -- throws inside the caller's own filter. This is the shape of a real
+    # template filter.
+    seen = DataType[]
+    by_voltage = function (T, component)
+        push!(seen, T)
+        return PSY.get_base_voltage(PSY.get_from(PSY.get_arc(component))) >= 100.0
+    end
+
+    catalog = PNM.BranchCatalog(nrd, by_voltage)
+    @test !isempty(seen)
+    @test all(T -> T <: PSY.ACTransmission, seen)
+    @test !any(T -> T <: PNM.AbstractReductionAggregate, seen)
+
+    # Every line here is 230 kV, so the filter keeps the composite arc.
+    arcs = Set(arc for (arc, _) in values(PNM.get_name_to_arc_map(catalog, PSY.Line)))
+    @test _composite_arc(nrd) in arcs
+
+    # A filter excluding everything drops the arc. That is a filter decision, not a lost
+    # entry, so closure does not apply to a filtered catalog.
+    empty_catalog = PNM.BranchCatalog(nrd, (T, c) -> false)
+    @test isempty(PNM.get_name_to_arc_map(empty_catalog, PSY.Line))
+end
+
+@testset "Nested filters fold per level, not over flattened leaves" begin
+    sys, nrd, _ = _nested_aggregate_catalog()
+    lines = Dict(PSY.get_name(l) => l for l in PSY.get_components(PSY.Line, sys))
+    keep(names) = (T, c) -> PSY.get_name(c) in names
+
+    # --- parallel inside series ---------------------------------------------------------
+    # Hand-built rather than reduced from a system: this shape needs a chain segment carrying
+    # two branches on one bus pair, which no fixture here produces.
+    group = PNM.BranchesParallel(PSY.Line[lines["L_1_10"], lines["L_1_20"]])
+    chain = PNM.BranchesSeries((1, 3))
+    PNM.add_branch!(chain, group, :FromTo)
+    PNM.add_branch!(chain, lines["L_11_3"], :FromTo)
+
+    # `any` within the parallel segment, `all` across segments: one qualifying member still
+    # carries that segment, so the chain qualifies. Folding `all` over flattened leaves
+    # would reject this, because `L_1_20` fails.
+    @test PNM._entry_matches(chain, keep(Set(["L_1_10", "L_11_3"])))
+
+    # No member of the parallel segment qualifies, so that segment is not carried.
+    @test !PNM._entry_matches(chain, keep(Set(["L_11_3"])))
+
+    # A failing plain segment fails the chain however well the group does.
+    @test !PNM._entry_matches(chain, keep(Set(["L_1_10", "L_1_20"])))
+
+    # --- series inside parallel ---------------------------------------------------------
+    real_group = PNM.get_parallel_branch_map(nrd)[_composite_arc(nrd)]
+
+    # `all` within each chain, `any` across them. One complete chain carries the arc...
+    @test PNM._entry_matches(real_group, keep(Set(["L_1_10", "L_10_11", "L_11_3"])))
+
+    # ...but one leaf from each chain does not: neither path is complete. Folding `any` over
+    # flattened leaves would wrongly accept this.
+    @test !PNM._entry_matches(real_group, keep(Set(["L_1_10", "L_1_20"])))
+end


### PR DESCRIPTION
Stacked on #350 — review that first; this diff is only the delta on top of it.

Reduction aggregates nest: a degree-two chain segment can be a parallel group, and sibling chains between the same bus pair are grouped into a `BranchesParallel{BranchesSeries}`. The catalog resolved entries to component types by unwrapping a fixed number of levels, so a group of chains was filed under `BranchesSeries` — a PNM wrapper type no `name_to_arc_map` consumer ever asks for. That arc left the index entirely, and because an absent type yields an empty map rather than an error, it did so silently: no flow variable, no rating constraint, no nodal-balance term, no complaint.

Depth stays small (2–4), but the number of *shapes* is combinatorial — series-of-parallel, parallel-of-series, mixed-of-either, 3W windings inside any of them. Per-shape methods scale with shapes; one recursion scales with neither.

## Changes

| file | change |
|---|---|
| `NetworkReductionData.jl` | `leaf_components` recursion; `_get_concrete_types` and `_get_segment_components` collapse from six per-shape methods to two |
| `BranchesParallel.jl` | `_entry_matches` recurses over direct members, `any` / `all` per node |
| `BranchesSeries.jl` | same, `all` across segments; `_chain_branches` deleted |
| `BranchCatalog.jl` | `_validate_catalog_closure`, opt-in via `BranchCatalog(nrd; validate = true)`, refused on a filtered catalog |
| `test_nested_reduction_aggregates.jl` | 32 assertions, reusing the existing `build_two_parallel_degree_two_chains()` fixture |

The filter fold ships here rather than as a follow-up because it has to: once the composite arc is reachable under `PSY.Line`, a predicate folded over direct members would be handed a `BranchesSeries`, and a filter written as `get_base_voltage(get_from(get_arc(x)))` throws a `MethodError` inside the caller's own code. Recursing means `predicate` is reached only through the leaf method, so it only ever sees PSY components.

Folding per level rather than over flattened leaves is a real distinction, not a refactor. A chain needs every segment, but a parallel segment within it needs only one member — flattening with `all` would let one filtered-out parallel sibling delete a corridor its twin still carries. The mirror case matters equally: a parallel of two chains that each have a gap must be rejected, and flattening with `any` would wrongly accept it. Both cases have explicit tests.

## Two open questions, deliberately not resolved here

**The `any`/`all` split.** `BranchesParallel` indexes when *any* member matches; `MixedBranchesParallel` requires *every* one. Same physical situation, opposite answer, decided by whether the members happen to share a concrete Julia type. This predates the PR, and I kept both operators as they were so no semantics change ships alongside a correctness fix — but recursion makes the inconsistency consequential at depth rather than merely odd. Worth settling. My read is `any` is right for both.

Underneath it: filtering decides *indexing*, not *physics*. The two-port is computed from all members regardless, so `any` hands the optimization a flow variable for a corridor whose equivalent admittance still includes the excluded branch. Defensible either way.

**A now-misleading warning.** `"Series circuit contains mixed branch types"` keys on `needs_insertion_order`, a proxy for "members have different Julia types" — which is now also true when a segment is an aggregate rather than a `Line`. Any nested chain trips it. Harmless, but it will confuse a reader.

## Testing

Full PNM suite green: 10,887,527 passing, 0 failures, 0 errors, ~303s. Formatter clean.

Note for anyone hitting `UndefVarError: get_system_uuid not defined in PowerSystems` locally — that is a stale test environment, not this branch. `Pkg.update()` in `test/` fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017XUcz3ZFnWmRgwgrDjKsBb