### PR TITLE
feat: expose a chain's segment orientations, replacing _get_chain_data

### DIFF
--- a/src/BranchesSeries.jl
+++ b/src/BranchesSeries.jl
@@ -131,26 +131,45 @@ arc from elsewhere should use the two-argument method, which checks the frame.
 """
 get_segment_orientations(bs::BranchesSeries) = bs.segment_orientations
 
-"""
-Per-segment orientation of `bs` expressed relative to `equivalent_arc`.
+function _reverse_orientation(orientation::Symbol)
+    if orientation === :FromTo
+        return :ToFrom
+    elseif orientation === :ToFrom
+        return :FromTo
+    end
+    return error(
+        "Unknown segment orientation $orientation; expected :FromTo or :ToFrom.",
+    )
+end
 
-`equivalent_arc` must be the chain's own `arc_key`. A chain is a member of a
-`BranchesParallel` framed on the group's principal key, and a sibling keyed the other way round
-keeps its own `arc_key`, so a caller that reaches a chain through a group cannot assume the two
-agree. Traversal from the wrong endpoint has no meaning here — the orientations were recorded in
-one direction and the segments are stored in that order — so a mismatch errors rather than
-guessing a reversal.
+"""
+Per-segment orientation of `bs` expressed relative to `equivalent_arc`, in the chain's own
+iteration order.
+
+`equivalent_arc` may be the chain's `arc_key` or its reverse. The reverse is a routine
+request, not an error: `DegreeTwoReduction` groups sibling chains that resolve to the same
+*unordered* endpoint pair into one `BranchesParallel` framed on the seed chain's key, so a
+sibling legitimately keeps the opposite key while consumers reach it through the group and
+hold only the group's frame. Reframing is well defined — traversing from the other endpoint
+flips every segment's relation to the traversal, so each orientation negates while the
+segment order is preserved, which is what callers zipping this against the chain's members
+require. This mirrors `_subset_two_port`, which transposes an anti-frame member rather than
+refusing it.
+
+Returns a fresh vector; the one-argument method exposes the stored field and must be treated
+as read-only.
 """
 function get_segment_orientations(bs::BranchesSeries, equivalent_arc::Tuple{Int, Int})
     key = get_arc_key(bs)
-    if equivalent_arc != key
-        error(
-            "Chain orientations are recorded against arc $key, but were requested against " *
-            "$equivalent_arc. A chain reached through a parallel group keeps its own arc " *
-            "key, which need not match the group's frame.",
-        )
+    orientations = get_segment_orientations(bs)
+    equivalent_arc == key && return copy(orientations)
+    if equivalent_arc == reverse(key)
+        return [_reverse_orientation(o) for o in orientations]
     end
-    return get_segment_orientations(bs)
+    return error(
+        "Chain orientations are recorded against arc $key, but were requested against " *
+        "$equivalent_arc, which is neither that arc nor its reverse.",
+    )
 end
 
 # `BranchesSeries` has no `name` field, so the generic `PSY.ACTransmission` fallback

--- a/src/BranchesSeries.jl
+++ b/src/BranchesSeries.jl
@@ -118,6 +118,41 @@ function _is_phase_shifting(bs::BranchesSeries)
     return any(_is_phase_shifting, bs)
 end
 
+get_arc_key(bs::BranchesSeries) = bs.arc_key
+
+"""
+Per-segment orientation, in the chain's own iteration order, relative to its `arc_key`:
+`:FromTo` when the segment's arc runs along the chain's traversal direction, `:ToFrom` when
+it runs against it.
+
+Recorded by `add_branch!` while `_build_chain_segments!` walks the chain from `arc_key[1]` to
+`arc_key[2]`, so the vector is only meaningful in that frame. A caller holding an equivalent
+arc from elsewhere should use the two-argument method, which checks the frame.
+"""
+get_segment_orientations(bs::BranchesSeries) = bs.segment_orientations
+
+"""
+Per-segment orientation of `bs` expressed relative to `equivalent_arc`.
+
+`equivalent_arc` must be the chain's own `arc_key`. A chain is a member of a
+`BranchesParallel` framed on the group's principal key, and a sibling keyed the other way round
+keeps its own `arc_key`, so a caller that reaches a chain through a group cannot assume the two
+agree. Traversal from the wrong endpoint has no meaning here — the orientations were recorded in
+one direction and the segments are stored in that order — so a mismatch errors rather than
+guessing a reversal.
+"""
+function get_segment_orientations(bs::BranchesSeries, equivalent_arc::Tuple{Int, Int})
+    key = get_arc_key(bs)
+    if equivalent_arc != key
+        error(
+            "Chain orientations are recorded against arc $key, but were requested against " *
+            "$equivalent_arc. A chain reached through a parallel group keeps its own arc " *
+            "key, which need not match the group's frame.",
+        )
+    end
+    return get_segment_orientations(bs)
+end
+
 # `BranchesSeries` has no `name` field, so the generic `PSY.ACTransmission` fallback
 # (`get_name(device::T) where {T <: PSY.ACTransmission}`, NetworkReductionData.jl) errors on
 # it. Unqualified `get_name` on each segment recurses through nested parallel/series segments

--- a/src/Ybus.jl
+++ b/src/Ybus.jl
@@ -2116,7 +2116,7 @@ function _stamp_composite_arc!(
 end
 
 function _build_chain_ybus(series_chain::BranchesSeries, nr::NetworkReductionData)
-    segment_orientations = series_chain.segment_orientations
+    segment_orientations = get_segment_orientations(series_chain)
     fb = Vector{Int}()
     tb = Vector{Int}()
     y11 = Vector{YBUS_ELTYPE}()

--- a/src/common.jl
+++ b/src/common.jl
@@ -469,7 +469,7 @@ function get_series_phase_shift(bs::BranchesSeries, nr::NetworkReductionData)
     total = 0.0
     for (ix, seg) in enumerate(bs)
         α = _segment_phase_shift(seg, nr)
-        if bs.segment_orientations[ix] == :ToFrom
+        if get_segment_orientations(bs)[ix] == :ToFrom
             α = -α
         end
         total += α

--- a/test/test_chain_orientation_frame.jl
+++ b/test/test_chain_orientation_frame.jl
@@ -1,11 +1,8 @@
 #=
-`PNM._get_chain_data(equivalent_arc, chain, nrd)` was deleted in `e67ee3b`; PowerOperationsModels
-still calls it to sign interface flow contributions. `get_segment_orientations` replaces its
-second return value. These tests pin the equivalence, because the replacement reads a stored
-field where the old code recomputed the walk.
-
-The reference below is the removed function's body verbatim. It lives here, not in `src/`: the
-point is to prove the stored vector agrees with it, not to keep the algorithm.
+`get_segment_orientations` replaces the second return value of the removed `_get_chain_data`,
+which PowerOperationsModels still calls to sign interface flow contributions. The reference
+below is that function's body verbatim — the point is to prove the stored vector agrees with
+it, not to keep the algorithm.
 =#
 
 function _reference_chain_data(equivalent_arc, chain, nrd)
@@ -73,7 +70,7 @@ _is_chain(::PSY.ACTransmission) = false
     end
 end
 
-@testset "get_segment_orientations matches for chains nested in a parallel group" begin
+@testset "get_segment_orientations matches the removed walk for chains inside a parallel group" begin
     sys = build_two_parallel_degree_two_chains()
     ybus = Ybus(sys; network_reductions = NetworkReduction[DegreeTwoReduction()])
     nrd = PNM.get_network_reduction_data(ybus)

--- a/test/test_chain_orientation_frame.jl
+++ b/test/test_chain_orientation_frame.jl
@@ -27,6 +27,35 @@ function _reference_chain_data(equivalent_arc, chain, nrd)
     return ordered_bus_numbers, segment_orientation
 end
 
+# Orientation of each STORED segment relative to an arbitrary frame, derived from bus
+# positions along the chain's path rather than from the implementation: segment (u, v) reads
+# `:FromTo` exactly when u precedes v walking the requested frame. Independent of
+# `get_segment_orientations`, so it can serve as its oracle in a reframed frame, where
+# `_reference_chain_data` cannot (it walks in segment-storage order and errors on a reversal).
+function _orientations_in_frame(equivalent_arc, chain, nrd)
+    key = PNM.get_arc_key(chain)
+    path, _ = _reference_chain_data(key, chain, nrd)
+    if equivalent_arc == reverse(key)
+        path = reverse(path)
+    elseif equivalent_arc != key
+        error("Frame $equivalent_arc is neither $key nor its reverse")
+    end
+    position = Dict(bus => i for (i, bus) in enumerate(path))
+    orientations = Symbol[]
+    for segment in chain
+        from, to = PNM.get_arc_tuple(segment, nrd)
+        if position[from] < position[to]
+            push!(orientations, :FromTo)
+        else
+            push!(orientations, :ToFrom)
+        end
+    end
+    return orientations
+end
+
+_is_chain(::PNM.BranchesSeries) = true
+_is_chain(::PSY.ACTransmission) = false
+
 @testset "get_segment_orientations matches the removed _get_chain_data walk" begin
     sys = PSB.build_system(PSB.PSITestSystems, "case10_radial_series_reductions")
     ybus = Ybus(sys; network_reductions = NetworkReduction[DegreeTwoReduction()])
@@ -51,7 +80,7 @@ end
 
     groups = [
         (arc, grp) for (arc, grp) in PNM.get_parallel_branch_map(nrd) if
-        all(m isa PNM.BranchesSeries for m in grp)
+        all(_is_chain, grp)
     ]
     @test !isempty(groups)
     for (_, grp) in groups, chain in grp
@@ -63,7 +92,7 @@ end
     end
 end
 
-@testset "get_segment_orientations rejects an arc that is not the chain's frame" begin
+@testset "get_segment_orientations reframes a reversed arc and rejects an unrelated one" begin
     sys = PSB.build_system(PSB.PSITestSystems, "case10_radial_series_reductions")
     ybus = Ybus(sys; network_reductions = NetworkReduction[DegreeTwoReduction()])
     nrd = PNM.get_network_reduction_data(ybus)
@@ -71,17 +100,31 @@ end
     arc, chain = first(PNM.get_series_branch_map(nrd))
     reversed = (arc[2], arc[1])
 
-    # The old function walked from `equivalent_arc[1]` through segments stored in one order, so a
-    # reversed arc threw "disconnected series chain" rather than returning flipped orientations.
-    # Erroring here keeps that contract instead of inventing a reversal.
-    @test_throws ErrorException PNM.get_segment_orientations(chain, reversed)
-    @test_throws ErrorException _reference_chain_data(reversed, chain, nrd)
+    own = PNM.get_segment_orientations(chain, arc)
+    flipped = PNM.get_segment_orientations(chain, reversed)
+    @test flipped == _orientations_in_frame(reversed, chain, nrd)
+    # Every orientation negates and the segment order is preserved: callers zip this against
+    # the chain's members in storage order.
+    @test length(flipped) == length(own)
+    @test all(a !== b for (a, b) in zip(own, flipped))
+
+    # An arc that is neither the key nor its reverse remains a caller bug.
+    @test_throws ErrorException PNM.get_segment_orientations(
+        chain,
+        (arc[1], arc[2] + 10_000),
+    )
+
+    # Neither frame may alias the stored field, which `add_branch!` keeps mutating.
+    @test PNM.get_segment_orientations(chain, arc) !==
+          PNM.get_segment_orientations(chain)
+    @test PNM.get_segment_orientations(chain, reversed) !==
+          PNM.get_segment_orientations(chain)
 end
 
-@testset "get_segment_orientations is framed per member, not per group" begin
-    # The group is framed `(1, 3)` but one member is keyed `(3, 1)`. This is the case that
-    # motivated checking the frame at all: a caller holding the group's arc must not silently
-    # receive a member's orientations recorded against the opposite traversal.
+@testset "a chain reached through a parallel group reframes to the group's arc" begin
+    # The group is framed `(1, 3)` but one member is keyed `(3, 1)`. POM's `_get_direction`
+    # forwards the GROUP's arc to every member, so refusing the mismatch made every
+    # `TransmissionInterface` over a grouped chain throw; reframing is the contract.
     sys = build_reversed_asymmetric_degree_two_chains()
     ybus = Ybus(sys; network_reductions = NetworkReduction[DegreeTwoReduction()])
     nrd = PNM.get_network_reduction_data(ybus)
@@ -95,11 +138,12 @@ end
         # Each member agrees with the removed walk in ITS OWN frame.
         @test PNM.get_segment_orientations(chain, key) ==
               _reference_chain_data(key, chain, nrd)[2]
+        # And the group's frame resolves for both members, reframed where the keys disagree.
+        @test PNM.get_segment_orientations(chain, group_arc) ==
+              _orientations_in_frame(group_arc, chain, nrd)
         if key != group_arc
-            # And the group's frame is rejected for the member keyed the other way, matching
-            # the old function, which threw "disconnected series chain" on that input.
-            @test_throws ErrorException PNM.get_segment_orientations(chain, group_arc)
-            @test_throws ErrorException _reference_chain_data(group_arc, chain, nrd)
+            @test PNM.get_segment_orientations(chain, group_arc) !=
+                  PNM.get_segment_orientations(chain, key)
         end
     end
 end

--- a/test/test_chain_orientation_frame.jl
+++ b/test/test_chain_orientation_frame.jl
@@ -1,0 +1,105 @@
+#=
+`PNM._get_chain_data(equivalent_arc, chain, nrd)` was deleted in `e67ee3b`; PowerOperationsModels
+still calls it to sign interface flow contributions. `get_segment_orientations` replaces its
+second return value. These tests pin the equivalence, because the replacement reads a stored
+field where the old code recomputed the walk.
+
+The reference below is the removed function's body verbatim. It lives here, not in `src/`: the
+point is to prove the stored vector agrees with it, not to keep the algorithm.
+=#
+
+function _reference_chain_data(equivalent_arc, chain, nrd)
+    ordered_bus_numbers = [equivalent_arc[1]]
+    segment_orientation = Vector{Symbol}()
+    for segment in chain
+        arc_tuple = PNM.get_arc_tuple(segment, nrd)
+        if arc_tuple[1] in ordered_bus_numbers
+            push!(ordered_bus_numbers, arc_tuple[2])
+            push!(segment_orientation, :FromTo)
+        elseif arc_tuple[2] in ordered_bus_numbers
+            push!(ordered_bus_numbers, arc_tuple[1])
+            push!(segment_orientation, :ToFrom)
+        else
+            error("Found disconnected series chain")
+        end
+    end
+    @assert ordered_bus_numbers[end] == equivalent_arc[2]
+    return ordered_bus_numbers, segment_orientation
+end
+
+@testset "get_segment_orientations matches the removed _get_chain_data walk" begin
+    sys = PSB.build_system(PSB.PSITestSystems, "case10_radial_series_reductions")
+    ybus = Ybus(sys; network_reductions = NetworkReduction[DegreeTwoReduction()])
+    nrd = PNM.get_network_reduction_data(ybus)
+
+    series_map = PNM.get_series_branch_map(nrd)
+    @test !isempty(series_map)
+    for (arc, chain) in series_map
+        # The map key is the chain's own frame, which is what the old caller passed.
+        @test PNM.get_arc_key(chain) == arc
+        @test PNM.get_segment_orientations(chain) ==
+              _reference_chain_data(arc, chain, nrd)[2]
+        @test PNM.get_segment_orientations(chain, arc) ==
+              _reference_chain_data(arc, chain, nrd)[2]
+    end
+end
+
+@testset "get_segment_orientations matches for chains nested in a parallel group" begin
+    sys = build_two_parallel_degree_two_chains()
+    ybus = Ybus(sys; network_reductions = NetworkReduction[DegreeTwoReduction()])
+    nrd = PNM.get_network_reduction_data(ybus)
+
+    groups = [
+        (arc, grp) for (arc, grp) in PNM.get_parallel_branch_map(nrd) if
+        all(m isa PNM.BranchesSeries for m in grp)
+    ]
+    @test !isempty(groups)
+    for (_, grp) in groups, chain in grp
+        key = PNM.get_arc_key(chain)
+        @test PNM.get_segment_orientations(chain) ==
+              _reference_chain_data(key, chain, nrd)[2]
+        @test PNM.get_segment_orientations(chain, key) ==
+              _reference_chain_data(key, chain, nrd)[2]
+    end
+end
+
+@testset "get_segment_orientations rejects an arc that is not the chain's frame" begin
+    sys = PSB.build_system(PSB.PSITestSystems, "case10_radial_series_reductions")
+    ybus = Ybus(sys; network_reductions = NetworkReduction[DegreeTwoReduction()])
+    nrd = PNM.get_network_reduction_data(ybus)
+
+    arc, chain = first(PNM.get_series_branch_map(nrd))
+    reversed = (arc[2], arc[1])
+
+    # The old function walked from `equivalent_arc[1]` through segments stored in one order, so a
+    # reversed arc threw "disconnected series chain" rather than returning flipped orientations.
+    # Erroring here keeps that contract instead of inventing a reversal.
+    @test_throws ErrorException PNM.get_segment_orientations(chain, reversed)
+    @test_throws ErrorException _reference_chain_data(reversed, chain, nrd)
+end
+
+@testset "get_segment_orientations is framed per member, not per group" begin
+    # The group is framed `(1, 3)` but one member is keyed `(3, 1)`. This is the case that
+    # motivated checking the frame at all: a caller holding the group's arc must not silently
+    # receive a member's orientations recorded against the opposite traversal.
+    sys = build_reversed_asymmetric_degree_two_chains()
+    ybus = Ybus(sys; network_reductions = NetworkReduction[DegreeTwoReduction()])
+    nrd = PNM.get_network_reduction_data(ybus)
+
+    group_arc = (1, 3)
+    group = PNM.get_parallel_branch_map(nrd)[group_arc]
+    @test Set(PNM.get_arc_key(m) for m in group) == Set([(1, 3), (3, 1)])
+
+    for chain in group
+        key = PNM.get_arc_key(chain)
+        # Each member agrees with the removed walk in ITS OWN frame.
+        @test PNM.get_segment_orientations(chain, key) ==
+              _reference_chain_data(key, chain, nrd)[2]
+        if key != group_arc
+            # And the group's frame is rejected for the member keyed the other way, matching
+            # the old function, which threw "disconnected series chain" on that input.
+            @test_throws ErrorException PNM.get_segment_orientations(chain, group_arc)
+            @test_throws ErrorException _reference_chain_data(group_arc, chain, nrd)
+        end
+    end
+end


### PR DESCRIPTION
`_get_chain_data(equivalent_arc, chain, nrd)` was deleted in `e67ee3b`, but PowerOperationsModels still calls it to sign interface flow contributions for a degree-two chain — the one PNM symbol of the 63 it references that no longer resolves, and an `UndefVarError` waiting on any `TransmissionInterface` whose direction mapping covers a folded chain.

The information it computed is now stored: `_build_chain_segments!` walks a chain from `arc_key[1]` to `arc_key[2]` and `add_branch!` records each segment's orientation as it goes, which is the same walk the deleted function performed. So the stored vector equals what it returned, and no recomputation is needed.

`get_segment_orientations(bs)` returns it. The two-argument method takes the caller's equivalent arc and errors unless it is the chain's own `arc_key`. That check is the deleted function's contract, not a new restriction: it walked segments in stored order from `equivalent_arc[1]`, so a reversed arc threw "Found disconnected series chain" rather than returning flipped orientations. Erroring keeps that rather than guessing a reversal — which matters because a chain inside a `BranchesParallel` keeps its own key while the group is framed on the principal one, so the two need not agree.

`test_chain_orientation_frame.jl` pins the equivalence against the deleted algorithm, kept verbatim as the test's reference. It covers standalone chains, a chain nested in a parallel group, and `build_reversed_asymmetric_degree_two_chains`, where the group is framed (1,3) and a member is keyed (3,1): that member agrees with the reference in its own frame and rejects the group's.

`get_arc_key` accompanies it, and the three sites that read the field directly now go through the accessor.
