### PR TITLE
Name mixed-group leaves with PNM's get_name, not PSY's

### DIFF
--- a/src/BranchCatalog.jl
+++ b/src/BranchCatalog.jl
@@ -71,11 +71,15 @@ _keep_all(::Type, ::Any) = true
 
 _is_unfiltered(predicate) = predicate === _keep_all
 
+# PNM's `get_name`, not `PSY.get_name`: a group's leaves can include a
+# `ThreeWindingTransformerCircuit`, whose fields are `(transformer, circuit, winding_number)`.
+# `PSY.get_name` resolves to IS's generic fallback, which reads `.name` and throws a
+# `FieldError` on it -- inside the logging call, and only once Debug logging is on.
 function _warn_mixed_group(kind::String, branches)
     @warn "$kind contains mixed branch types, filters might be applied to more " *
           "components than intended. Use Logging.Debug for additional information."
     @debug "$kind branch types: $(typeof.(branches))"
-    @debug "$kind branch names: $(PSY.get_name.(branches))"
+    @debug "$kind branch names: $(get_name.(branches))"
     return
 end
 

--- a/test/test_nested_reduction_aggregates.jl
+++ b/test/test_nested_reduction_aggregates.jl
@@ -109,6 +109,42 @@ end
     @test isempty(PNM.get_name_to_arc_map(empty_catalog, PSY.Line))
 end
 
+@testset "Mixed-group debug logging survives a three-winding wrapper" begin
+    # `_warn_mixed_group`'s `@debug` line is only evaluated once Debug logging is on, so a
+    # bad `get_name` there is invisible until someone turns it on. A group's leaves can
+    # include a `ThreeWindingTransformerCircuit`, whose fields are
+    # `(transformer, circuit, winding_number)` -- `PSY.get_name` resolves to IS's generic
+    # fallback, reads `.name`, and throws.
+    sys = PSB.build_system(PSB.PSITestSystems, "c_sys5_ml")
+    busD = PSY.get_component(PSY.ACBus, sys, "nodeD")
+    sec_bus, ter_bus, star_bus = _add_star_buses!(sys, busD)
+    t3w = _add_three_winding_transformer!(
+        sys, busD, sec_bus, ter_bus, star_bus; name = "T3W_mixed_group",
+    )
+    winding = PNM.ThreeWindingTransformerCircuit(t3w, 1)
+    line = first(PSY.get_components(PSY.Line, sys))
+
+    @test PNM.get_name(winding) == "T3W_mixed_group_winding_1"
+    @test_throws Exception PSY.get_name(winding)
+
+    group = PNM.MixedBranchesParallel(PSY.ACTransmission[winding, line])
+
+    # `Test.collect_test_logs` with `min_level = Debug` is what actually forces the `@debug`
+    # message to be built. A plain `ConsoleLogger(devnull, Debug)` does not: the body stays
+    # unevaluated, and the test passes whether or not the name lookup is correct.
+    matched = nothing
+    records, _ = Test.collect_test_logs(; min_level = Logging.Debug) do
+        matched = PNM._entry_matches(group, (T, c) -> true)
+    end
+    @test matched === true
+
+    # Both the warning and the two debug lines must have been emitted -- if the debug
+    # message threw while being built, we would not get here at all.
+    @test count(r -> r.level == Logging.Warn, records) == 1
+    @test count(r -> r.level == Logging.Debug, records) == 2
+    @test any(r -> occursin("T3W_mixed_group_winding_1", r.message), records)
+end
+
 @testset "Nested filters fold per level, not over flattened leaves" begin
     sys, nrd, _ = _nested_aggregate_catalog()
     lines = Dict(PSY.get_name(l) => l for l in PSY.get_components(PSY.Line, sys))


### PR DESCRIPTION
`_warn_mixed_group` builds its `@debug` message with `PSY.get_name`:

```julia
@debug "$kind branch names: $(PSY.get_name.(branches))"
```

A group's leaves can include a `ThreeWindingTransformerCircuit`, whose fields are `(transformer, circuit, winding_number)`. `PSY.get_name` falls through to IS's generic `InfrastructureSystemsComponent` method, reads `.name`, and throws a `FieldError`. `BranchesParallel.jl` carries a comment saying exactly this about `get_name` ten lines away.

Unqualified `get_name` dispatches PNM's wrapper method and forwards to `PSY.get_name` for real components.

### Why it stayed hidden

`@debug` does not build its message unless Debug logging is on, so the crash only happens to someone who turned Debug on to investigate the mixed-group warning the same function just emitted.

That is also why the regression test uses `Test.collect_test_logs(; min_level = Logging.Debug)`. A plain `ConsoleLogger(devnull, Logging.Debug)` does **not** force the body to evaluate — a test written that way passes against the broken code. Verified both directions: 6 pass with the fix, `FieldError: type ThreeWindingTransformerCircuit has no field 'name'` without it.

### Provenance

Reported by Copilot on #350. Pre-existing — the same call lived in `add_to_map` before #350 relocated it — but #351 widened its reach: `_entry_matches` now passes leaves rather than direct members, so a winding nested inside a chain segment reaches it where only a direct member could before.

This fix was written on the #351 branch and pushed after #351 was merged, so it missed the merge. Rebased onto `psy6` unchanged; cherry-picked clean over the type-stability and dispatch refactors that landed since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017XUcz3ZFnWmRgwgrDjKsBb