### PR TITLE
Type the reduction kind instead of tagging it with a Symbol

### DIFF
--- a/src/BranchCatalog.jl
+++ b/src/BranchCatalog.jl
@@ -1,7 +1,41 @@
-const ARC_ENTRY = Tuple{Tuple{Int, Int}, Symbol}
+"""
+How an arc of the reduced network came to exist.
+
+Not stored anywhere: the entry occupying an arc already determines its provenance, so
+[`arc_provenance`](@ref) reads it back by dispatch. A stored copy would be a second source of
+truth for something the type system already knows, and the pair can drift — the `Symbol` this
+replaced was compared against `String` literals across a package boundary, where every arm was
+silently `false`.
+
+Radial reduction has no member here on purpose. It removes an arc rather than producing one,
+so there is nothing left to describe; its work is injection remapping through
+`bus_reduction_map`.
+"""
+abstract type ArcProvenance end
+
+"One physical branch holding its arc alone, untouched by any reduction."
+struct DirectArc <: ArcProvenance end
+
+"Two or more branches on one bus pair, folded into a single parallel group."
+struct ParallelArc <: ArcProvenance end
+
+"A degree-two chain, folded into one arc spanning the chain's endpoints."
+struct SeriesArc <: ArcProvenance end
+
+"""
+A Ward equivalent: admittance produced by Gaussian elimination, backed by no component.
+
+Nothing routes such an arc into a `BranchCatalog` yet, but a `PSY.GenericArcImpedance`
+subtypes `PSY.ACTransmission`, so without this arm one would answer [`DirectArc`](@ref) from
+the blanket method and claim component backing it does not have.
+"""
+struct SyntheticArc <: ArcProvenance end
+
+const ARC_ENTRY = Tuple{Tuple{Int, Int}, ArcProvenance}
 const NAME_TO_ARC = Dict{DataType, DataStructures.SortedDict{String, ARC_ENTRY}}
 const COMPONENT_TO_ENTRY = Dict{DataType, Dict{String, String}}
-const COMPONENT_NAME_INDEX = Dict{String, Vector{Tuple{DataType, Tuple{Int, Int}, Symbol}}}
+const COMPONENT_NAME_INDEX =
+    Dict{String, Vector{Tuple{DataType, Tuple{Int, Int}, ArcProvenance}}}
 
 # Shared empty-map sentinels returned on a miss; callers must never mutate these.
 const EMPTY_NAME_TO_ARC_MAP = DataStructures.SortedDict{String, ARC_ENTRY}()
@@ -86,6 +120,69 @@ end
 _entry_matches(device::T, predicate) where {T <: PSY.ACTransmission} =
     predicate(T, device)
 
+"""
+    arc_provenance(entry) -> ArcProvenance
+
+How the arc `entry` occupies came to exist, read off the entry's own type.
+
+The blanket arm answers for a single physical branch, so the two `AbstractReductionAggregate`
+subtypes need arms of their own -- they subtype `PSY.ACTransmission` and would otherwise be
+claimed by it and reported as untouched by any reduction. This is the hazard
+[`AbstractReductionAggregate`](@ref) exists to make visible.
+"""
+arc_provenance(::PSY.ACTransmission) = DirectArc()
+arc_provenance(::AbstractBranchesParallel) = ParallelArc()
+arc_provenance(::BranchesSeries) = SeriesArc()
+arc_provenance(::PSY.GenericArcImpedance) = SyntheticArc()
+
+"""
+    _branch_multiplier(provenance, catalog, branch_name, arc) -> Float64
+
+Factor scaling a per-arc matrix entry to the named branch's share of it, dispatched on how
+the arc came to exist. Backs [`get_branch_multiplier`](@ref).
+
+Each arm states its own reason, which is what the `kind === :direct_branch_map` test this
+replaced could not: everything that was not direct fell to the parallel branch, so a series
+or Ward arc reaching here produced a `KeyError` from the parallel map rather than saying what
+was wrong.
+"""
+_branch_multiplier(::DirectArc, ::BranchCatalog, ::String, ::Tuple{Int, Int}) = 1.0
+
+# Backed by no component, so nothing shares it.
+_branch_multiplier(::SyntheticArc, ::BranchCatalog, ::String, ::Tuple{Int, Int}) = 1.0
+
+# A member carries its susceptance-fraction share of the group flow.
+function _branch_multiplier(
+    ::ParallelArc,
+    catalog::BranchCatalog,
+    branch_name::String,
+    arc::Tuple{Int, Int},
+)
+    group = get_parallel_branch_map(get_network_reduction_data(catalog))[arc]
+    for member in group
+        get_name(member) == branch_name || continue
+        return compute_parallel_multiplier(group, member)
+    end
+    return error(
+        "Branch $branch_name is indexed on arc $(arc) but no member of the group there " *
+        "carries that name.",
+    )
+end
+
+# Unreachable today -- `_build_component_name_index` indexes no series entry -- but the arm
+# names the limitation instead of failing as a missing key somewhere else.
+_branch_multiplier(
+    ::SeriesArc,
+    ::BranchCatalog,
+    branch_name::String,
+    arc::Tuple{Int, Int},
+) =
+    error(
+        "Branch $branch_name is a segment of the series chain on arc $(arc). A chain's " *
+        "flow does not decompose into per-segment shares of one matrix row, so it has no " *
+        "multiplier; resolve the segment by component identity instead.",
+    )
+
 ##############################################################################
 ############################## Index building ################################
 ##############################################################################
@@ -112,7 +209,6 @@ function _index_forward!(
     dest::Dict{DataType, Any},
     name_to_arc::NAME_TO_ARC,
     source,
-    kind::Symbol,
     predicate,
     bucket_types,
     empty_bucket,
@@ -121,7 +217,8 @@ function _index_forward!(
         _entry_matches(entry, predicate) || continue
         for T in bucket_types(entry)
             _store!(get!(() -> empty_bucket(entry), dest, T), arc, entry)
-            _bucket_name_to_arc(name_to_arc, T)[get_name(entry)] = (arc, kind)
+            _bucket_name_to_arc(name_to_arc, T)[get_name(entry)] =
+                (arc, arc_provenance(entry))
         end
     end
     return
@@ -173,7 +270,7 @@ function _index_series!(
                     chain,
                 )
                 _bucket_name_to_arc(name_to_arc, T)[get_name(segment)] =
-                    (arc, :series_branch_map)
+                    (arc, arc_provenance(chain))
                 names = _bucket_entry_names(component_to_entry, T)
                 for component in _get_segment_components(segment)
                     names[get_name(component)] = get_name(segment)
@@ -202,7 +299,7 @@ function _index_reverse_series!(dest::Dict{DataType, Any}, source, predicate)
 end
 
 _name_candidates(index::COMPONENT_NAME_INDEX, name::String) =
-    get!(() -> Tuple{DataType, Tuple{Int, Int}, Symbol}[], index, name)
+    get!(() -> Tuple{DataType, Tuple{Int, Int}, ArcProvenance}[], index, name)
 
 """
 Component-name index for name-based matrix indexing (`get_branch_multiplier`), whose API takes
@@ -218,14 +315,16 @@ function _build_component_name_index(nrd::NetworkReductionData, predicate)
         _entry_matches(entry, predicate) || continue
         push!(
             _name_candidates(index, get_name(entry)),
-            (typeof(entry), arc, :direct_branch_map),
+            (typeof(entry), arc, arc_provenance(entry)),
         )
     end
     for (member, arc) in nrd.reverse_parallel_branch_map
         _entry_matches(member, predicate) || continue
+        # Provenance describes the arc, not the component: the key here is a member, whose own
+        # type would answer `DirectArc`. The group holding the arc is what to ask.
         push!(
             _name_candidates(index, get_name(member)),
-            (typeof(member), arc, :parallel_branch_map),
+            (typeof(member), arc, arc_provenance(nrd.parallel_branch_map[arc])),
         )
     end
     return index
@@ -300,7 +399,7 @@ function BranchCatalog(nrd::NetworkReductionData, predicate; validate::Bool = fa
 
     _index_forward!(
         maps.direct_branch_map, name_to_arc, nrd.direct_branch_map,
-        :direct_branch_map, predicate,
+        predicate,
         entry -> (_get_segment_type(entry),),
         entry -> Dict{Tuple{Int, Int}, typeof(entry)}(),
     )
@@ -311,7 +410,7 @@ function BranchCatalog(nrd::NetworkReductionData, predicate; validate::Bool = fa
 
     _index_forward!(
         maps.parallel_branch_map, name_to_arc, nrd.parallel_branch_map,
-        :parallel_branch_map, predicate,
+        predicate,
         _get_concrete_types,
         _ -> _empty_parallel_branch_map(),
     )

--- a/src/PowerNetworkMatrix.jl
+++ b/src/PowerNetworkMatrix.jl
@@ -403,16 +403,6 @@ function get_branch_multiplier(A::T, branch_name::String) where {T <: PowerNetwo
             "names are unique only per type.",
         )
     end
-    (_, arc_tuple, kind) = only(candidates)
-    kind === :direct_branch_map && return 1.0, arc_tuple
-    # A parallel-group member carries its susceptance-fraction share of the group flow.
-    group = get_parallel_branch_map(get_network_reduction_data(catalog))[arc_tuple]
-    for member in group
-        get_name(member) == branch_name || continue
-        return compute_parallel_multiplier(group, member), arc_tuple
-    end
-    error(
-        "Branch $branch_name is indexed on arc $(arc_tuple) but no member of the group " *
-        "there carries that name.",
-    )
+    (_, arc_tuple, provenance) = only(candidates)
+    return _branch_multiplier(provenance, catalog, branch_name, arc_tuple), arc_tuple
 end

--- a/test/test_branch_catalog.jl
+++ b/test/test_branch_catalog.jl
@@ -79,11 +79,11 @@ end
     # The group is reachable under the parent transformer type.
     parent = PSY.ThreeWindingTransformer
     arc_map = PNM.get_name_to_arc_map(catalog, parent)
-    @test any(v -> v == (merged_arc, :parallel_branch_map), values(arc_map))
+    @test any(v -> v == (merged_arc, PNM.ParallelArc()), values(arc_map))
 
     # And through the wrapper-keyed accessor, which redirects to the parent.
     wrapper_map = PNM.get_name_to_arc_map(catalog, PNM.ThreeWindingTransformerCircuit)
-    @test any(v -> v == (merged_arc, :parallel_branch_map), values(wrapper_map))
+    @test any(v -> v == (merged_arc, PNM.ParallelArc()), values(wrapper_map))
 
     # No bucket anywhere is keyed by the wrapper type.
     maps = PNM.get_all_branch_maps_by_type(catalog)
@@ -152,4 +152,76 @@ end
     @test err isa ErrorException
     @test occursin("Line", err.msg)
     @test occursin("TwoWindingTransformer", err.msg)
+end
+
+@testset "arc_provenance answers from the entry's type" begin
+    # The blanket arm is `::PSY.ACTransmission`, which aggregates subtype. Each aggregate
+    # needs its own arm or it is silently reported as an untouched physical branch -- the
+    # hazard `AbstractReductionAggregate` exists to expose.
+    sys = build_two_parallel_degree_two_chains()
+    ybus = Ybus(sys; network_reductions = NetworkReduction[DegreeTwoReduction()])
+    nrd = PNM.get_network_reduction_data(ybus)
+
+    line = first(PSY.get_components(PSY.Line, sys))
+    @test PNM.arc_provenance(line) == PNM.DirectArc()
+
+    chains = PNM.get_series_branch_map(nrd)
+    groups = PNM.get_parallel_branch_map(nrd)
+    @test !isempty(groups)
+    for (_, group) in groups
+        @test PNM.arc_provenance(group) == PNM.ParallelArc()
+        @test PNM.arc_provenance(group) != PNM.DirectArc()
+    end
+    for (_, chain) in chains
+        @test PNM.arc_provenance(chain) == PNM.SeriesArc()
+        @test PNM.arc_provenance(chain) != PNM.DirectArc()
+    end
+
+    # A Ward equivalent is a PSY component, so only its own arm keeps it from claiming the
+    # component backing that `DirectArc` asserts.
+    ward_arc = PSY.GenericArcImpedance(;
+        name = "ward_equivalent",
+        available = true,
+        active_power_flow = 0.0,
+        reactive_power_flow = 0.0,
+        max_flow = 1e6,
+        arc = PSY.Arc(nothing),
+        r = 0.01,
+        x = 0.1,
+    )
+    @test PNM.arc_provenance(ward_arc) == PNM.SyntheticArc()
+end
+
+@testset "Provenance reaches the name-to-arc index and the multiplier" begin
+    sys = build_two_parallel_degree_two_chains()
+    ybus = Ybus(sys; network_reductions = NetworkReduction[DegreeTwoReduction()])
+    catalog = PNM.get_branch_catalog(ybus)
+
+    # Every entry carries a provenance singleton, never a bare symbol.
+    seen = Set{PNM.ArcProvenance}()
+    for (_, by_name) in PNM.get_name_to_arc_maps(catalog)
+        for (_, provenance) in values(by_name)
+            @test provenance isa PNM.ArcProvenance
+            push!(seen, provenance)
+        end
+    end
+    # This fixture folds sibling chains into one parallel group, so both kinds appear.
+    @test PNM.ParallelArc() in seen
+
+    # `get_branch_multiplier` now routes by provenance rather than by an equality test that
+    # sent everything non-direct down the parallel path.
+    @test PNM._branch_multiplier(PNM.DirectArc(), catalog, "anything", (1, 3)) == 1.0
+    @test PNM._branch_multiplier(PNM.SyntheticArc(), catalog, "anything", (1, 3)) == 1.0
+
+    # A series segment reports why it has no multiplier instead of failing as a missing key
+    # in the parallel map.
+    err = try
+        PNM._branch_multiplier(PNM.SeriesArc(), catalog, "L_1_10", (1, 3))
+        nothing
+    catch e
+        e
+    end
+    @test err isa ErrorException
+    @test occursin("series chain", err.msg)
+    @test occursin("component identity", err.msg)
 end

--- a/test/testing_data.jl
+++ b/test/testing_data.jl
@@ -887,8 +887,8 @@ function branch_index_fingerprint(
 
     names = Tuple{String, String, Tuple{Int, Int}, String}[]
     for (T, submap) in name_to_arc
-        for (name, (arc, kind)) in submap
-            push!(names, (string(T), name, arc, String(kind)))
+        for (name, (arc, provenance)) in submap
+            push!(names, (string(T), name, arc, string(provenance)))
         end
     end
     sort!(names)


### PR DESCRIPTION
First slice of #352. Replaces `BranchCatalog`'s `kind::Symbol` tag with an `ArcProvenance` type hierarchy, read off the entry by dispatch.

```julia
abstract type ArcProvenance end
struct DirectArc    <: ArcProvenance end  # one physical branch, holding its arc alone
struct ParallelArc  <: ArcProvenance end  # branches on one bus pair, folded into a group
struct SeriesArc    <: ArcProvenance end  # a degree-two chain folded into one arc
struct SyntheticArc <: ArcProvenance end  # Ward: admittance, no backing component

arc_provenance(::PSY.ACTransmission)       = DirectArc()
arc_provenance(::AbstractBranchesParallel) = ParallelArc()
arc_provenance(::BranchesSeries)           = SeriesArc()
arc_provenance(::PSY.GenericArcImpedance)  = SyntheticArc()
```

Radial has no member on purpose: it removes an arc rather than producing one, so there is nothing left to describe.

## Why

**It was a second source of truth.** The entry already determines how its arc came to exist, so the `Symbol` restated in a parameter what the type knew. `_index_forward!` loses the `kind` argument entirely — there is no longer a value to pass wrongly.

**It was stringly typed across a package boundary.** POM's `get_ptdf_orientation_sign` compares the slot against `String` literals:

```julia
arc, reduction = PNM.get_name_to_arc_maps(net_reduction_data)[T][name]
if reduction == "direct_branch_map" || ...
```

`Symbol` never equals `String`, so every arm is dead and the function falls through to its trailing `error()` for every branch on every path. It survives only because area-interchange is the sole caller. **This PR does not fix that** — the fix is POM-side, and a singleton compares just as unequal to a string. What changes is that the mistake becomes reachable by dispatch instead of by literal.

**It flattened four cases into two.** `get_branch_multiplier` tested `kind === :direct_branch_map` and sent everything else down the parallel path, so a series or Ward arc died on a `KeyError` from the parallel map. Each provenance now has an arm stating its own reason.

## Notes

- `SyntheticArc` and the `SeriesArc` multiplier arm are unreachable today. `SyntheticArc` earns its place on correctness: `GenericArcImpedance` subtypes `PSY.ACTransmission`, so without it a Ward arc answers `DirectArc` and asserts component backing it lacks. Same reason the two `AbstractReductionAggregate` subtypes need arms — the hazard that type exists to expose.
- `_build_component_name_index` is the one site that cannot simply ask the value it holds: `reverse_parallel_branch_map` is keyed by *member*, whose own type answers `DirectArc`. Provenance describes the arc, so it resolves the group first.
- The hierarchy lives in `BranchCatalog.jl`, not `definitions.jl` — its only consumers are the `ARC_ENTRY` alias, `arc_provenance` and `_branch_multiplier`, all local, and `definitions.jl` is otherwise numeric constants. Include order does not force it earlier: that constrains method signatures, and `get_branch_multiplier` only calls the helper.
- **The second tuple slot stays.** It is derived-and-stored, which is what this PR argues against, but removing it breaks POM's `(arc, reduction)` destructuring in ~8 places and buys nothing until those consumers dispatch on the entry.

## Not in scope

The arc-keyed table (#352 item 2) is blocked on deriving entry names from arcs (item 1): `_index_series!` files a chain under each *segment's* name while `_index_forward!` files one entry name per arc, so merging the walks changes which names exist — and those names key POM's result tables.

## Testing

- Full suite: **10,887,574 passing, 0 failures** (182 s).
- Docs build: clean (`make.jl` exit 0, cross-references resolved).
- Formatter: no changes.

Two new testsets, 17 assertions: `arc_provenance` answers per entry type (including that an aggregate is *not* `DirectArc`), provenance reaches `name_to_arc`, and each multiplier arm.

Note for anyone whose CI ran on the first push: those failures were an upstream precompile break, not this change. PowerSystems `psy6` #1778 landed at 11:05 and its InfrastructureSystems `IS4` counterpart #628 at 12:01, and anything resolving in between failed with `TypeError: ... got Type{InfrastructureSystems.TimeSeriesKey}` before any PNM source loaded. Fixed upstream; re-running CI is enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017XUcz3ZFnWmRgwgrDjKsBb