### PR TITLE
Name reduced arcs for the arc, not for their members

### DIFF
--- a/src/BranchCatalog.jl
+++ b/src/BranchCatalog.jl
@@ -86,6 +86,28 @@ end
 _entry_matches(device::T, predicate) where {T <: PSY.ACTransmission} =
     predicate(T, device)
 
+"""
+    _entry_name(arc, entry) -> String
+
+The name an arc's entry is indexed under.
+
+A direct arc is one branch and keeps that branch's own name: it is already unique per type,
+already stable, and renaming it would move result keys for the ~90% of arcs no reduction
+touched. A composite arc takes its name from the arc instead.
+
+Deriving a composite's name here rather than on the aggregate is deliberate on two counts.
+The catalog knows the arc the entry is *filed under*, while an aggregate's `arc_key` holds
+original bus numbers that `reverse_bus_search_map` may since have remapped -- the two can
+disagree. And `_composite_entries` admits at most one composite per unordered bus pair, so
+arc => name is injective by construction here, where on the aggregate it was the longest
+common prefix of member names: `La`/`Lb` and `Lc`/`Ld` both yielded `Lseries_chain`, and the
+name moved whenever membership did.
+"""
+_entry_name(::Tuple{Int, Int}, entry::PSY.ACTransmission) = get_name(entry)
+_entry_name(arc::Tuple{Int, Int}, ::AbstractBranchesParallel) =
+    "parallel_$(arc[1])_$(arc[2])"
+_entry_name(arc::Tuple{Int, Int}, ::BranchesSeries) = "series_$(arc[1])_$(arc[2])"
+
 ##############################################################################
 ############################## Index building ################################
 ##############################################################################
@@ -121,7 +143,7 @@ function _index_forward!(
         _entry_matches(entry, predicate) || continue
         for T in bucket_types(entry)
             _store!(get!(() -> empty_bucket(entry), dest, T), arc, entry)
-            _bucket_name_to_arc(name_to_arc, T)[get_name(entry)] = (arc, kind)
+            _bucket_name_to_arc(name_to_arc, T)[_entry_name(arc, entry)] = (arc, kind)
         end
     end
     return
@@ -147,7 +169,7 @@ function _index_reverse!(
         T = _get_segment_type(member)
         _store!(get!(() -> Dict{typeof(member), Tuple{Int, Int}}(), dest, T), member, arc)
         _bucket_entry_names(component_to_entry, T)[get_name(member)] =
-            get_name(forward[arc])
+            _entry_name(arc, forward[arc])
     end
     return
 end
@@ -155,6 +177,11 @@ end
 """
 Index the series map. A chain is filed under every type appearing anywhere in it, so a caller
 iterating one branch type finds every chain that type participates in.
+
+One entry name per arc, not one per segment. A folded chain is a single corridor carrying a
+single flow, so it has one identity, and the parallel map has always filed groups this way --
+filing chains per segment made the two maps disagree about what an entry *is*. Members reach
+their entry through `component_to_entry`, which is where the per-component view belongs.
 """
 function _index_series!(
     dest::Dict{DataType, Any},
@@ -165,20 +192,22 @@ function _index_series!(
 )
     for (arc, chain) in source
         _entry_matches(chain, predicate) || continue
-        for segment in chain
-            for T in _get_concrete_types(segment)
-                _store!(
-                    get!(() -> Dict{Tuple{Int, Int}, BranchesSeries}(), dest, T),
-                    arc,
-                    chain,
-                )
-                _bucket_name_to_arc(name_to_arc, T)[get_name(segment)] =
-                    (arc, :series_branch_map)
-                names = _bucket_entry_names(component_to_entry, T)
-                for component in _get_segment_components(segment)
-                    names[get_name(component)] = get_name(segment)
-                end
-            end
+        name = _entry_name(arc, chain)
+        for T in _get_concrete_types(chain)
+            _store!(
+                get!(() -> Dict{Tuple{Int, Int}, BranchesSeries}(), dest, T),
+                arc,
+                chain,
+            )
+            _bucket_name_to_arc(name_to_arc, T)[name] = (arc, :series_branch_map)
+        end
+        # Each leaf redirects to the one entry carrying its flow, filed under the leaf's own
+        # bucket rather than under every type in the chain.
+        for leaf in leaf_components(chain)
+            _bucket_entry_names(component_to_entry, _get_segment_type(leaf))[get_name(
+                leaf,
+            )] =
+                name
         end
     end
     return

--- a/src/BranchesParallel.jl
+++ b/src/BranchesParallel.jl
@@ -77,18 +77,23 @@ function _is_phase_shifting(bp::AbstractBranchesParallel)
 end
 
 """
-An aggregate's name is its arc, spelled `parallel_<from>_<to>`.
+An aggregate's name is its arc, spelled `<from>_<to>_double_circuit`.
+
+`double_circuit` is kept from the previous scheme: it is what tells a reader of results that
+the row is a total across the parallel members rather than one member's own flow. Only the
+stem changed, from the members' longest common prefix to the arc.
 
 The bus numbers are the group's own `arc_key`, i.e. the endpoints as they stood when the
 group was formed; a later reduction can remap them, so this is an identity for reading, not a
 key to look the group up with. `BranchCatalog._entry_name` derives the *indexed* name from
 the arc the catalog files the entry under, which is the remapped one.
 
-This replaced the longest common prefix of the member names, which was not injective -- `La`
-∥ `Lb` and `Lc` ∥ `Ld` both produced `Ldouble_circuit` -- and which moved whenever membership
-did, so a corridor was renamed by the act of adding a circuit to it.
+The prefix stem was not injective -- `La` ∥ `Lb` and `Lc` ∥ `Ld` both produced
+`Ldouble_circuit` -- and it moved whenever membership did, so a corridor was renamed by the
+act of adding a circuit to it. The arc stem is injective by construction.
 """
-get_name(bp::AbstractBranchesParallel) = "parallel_$(bp.arc_key[1])_$(bp.arc_key[2])"
+get_name(bp::AbstractBranchesParallel) =
+    "$(bp.arc_key[1])_$(bp.arc_key[2])_double_circuit"
 
 """
     compute_parallel_multiplier(parallel_branch_set, branch) -> Float64

--- a/src/BranchesParallel.jl
+++ b/src/BranchesParallel.jl
@@ -76,35 +76,19 @@ function _is_phase_shifting(bp::AbstractBranchesParallel)
     return any(_is_phase_shifting, bp.branches)
 end
 
-# PNM's `get_name`, not `PSY.get_name`: a group can contain a `ThreeWindingTransformerCircuit`
-# (windings register through the merge-aware branch-map path), and that wrapper has no `name`
-# field for PSY to read.
-function get_name(bp::AbstractBranchesParallel)
-    member_names = get_name.(bp.branches)
-    base_string = _longest_starting_substring(member_names...)
-    if isempty(base_string)
-        base_string = join(member_names, "_") * "_"
-    end
-    return base_string *= "double_circuit"
-end
+"""
+An aggregate's name is its arc, spelled `parallel_<from>_<to>`.
 
-function _longest_starting_substring(branch_names...)
-    first_name = first(branch_names)
-    n_chars = minimum(length.(branch_names))
-    n_branches = length(branch_names)
-    for ix in 1:n_chars
-        for jx in 2:n_branches
-            if branch_names[jx][ix] != first_name[ix]
-                if ix == 1
-                    return ""
-                else
-                    return first_name[1:(ix - 1)]
-                end
-            end
-        end
-    end
-    return first_name[1:n_chars]
-end
+The bus numbers are the group's own `arc_key`, i.e. the endpoints as they stood when the
+group was formed; a later reduction can remap them, so this is an identity for reading, not a
+key to look the group up with. `BranchCatalog._entry_name` derives the *indexed* name from
+the arc the catalog files the entry under, which is the remapped one.
+
+This replaced the longest common prefix of the member names, which was not injective -- `La`
+∥ `Lb` and `Lc` ∥ `Ld` both produced `Ldouble_circuit` -- and which moved whenever membership
+did, so a corridor was renamed by the act of adding a circuit to it.
+"""
+get_name(bp::AbstractBranchesParallel) = "parallel_$(bp.arc_key[1])_$(bp.arc_key[2])"
 
 """
     compute_parallel_multiplier(parallel_branch_set, branch) -> Float64

--- a/src/BranchesSeries.jl
+++ b/src/BranchesSeries.jl
@@ -172,18 +172,16 @@ function get_segment_orientations(bs::BranchesSeries, equivalent_arc::Tuple{Int,
     )
 end
 
-# `BranchesSeries` has no `name` field, so the generic `PSY.ACTransmission` fallback
-# (`get_name(device::T) where {T <: PSY.ACTransmission}`, NetworkReductionData.jl) errors on
-# it. Unqualified `get_name` on each segment recurses through nested parallel/series segments
-# the same way `_is_phase_shifting` does.
-function get_name(bs::BranchesSeries)
-    names = [get_name(br) for br in bs]
-    base_string = _longest_starting_substring(names...)
-    if isempty(base_string)
-        base_string = join(names, "_") * "_"
-    end
-    return base_string *= "series_chain"
-end
+"""
+A chain's name is its arc, spelled `series_<from>_<to>`. See the `AbstractBranchesParallel`
+method (BranchesParallel.jl) for why the aggregate spells its own key and the catalog spells
+the indexed one.
+
+A nested chain keeps its own frame, so two siblings in one group can name themselves from
+opposite endpoint orders -- they are not indexed, and #353 established that a nested chain's
+`arc_key` is a traversal frame rather than an identity.
+"""
+get_name(bs::BranchesSeries) = "series_$(bs.arc_key[1])_$(bs.arc_key[2])"
 
 function get_series_susceptance(
     series_chain::BranchesSeries,

--- a/test/PowerNetworkMatricesTests.jl
+++ b/test/PowerNetworkMatricesTests.jl
@@ -30,12 +30,13 @@ Aqua.test_stale_deps(
     PowerNetworkMatrices;
     ignore = [
         :Pardiso,
+        :InfrastructureCoreOpenAPIModels,
+        :InfrastructureTimeSeriesOpenAPIModels,
         :PowerCoreOpenAPIModels,
         :PowerDynamicsOpenAPIModels,
         :PowerInvestmentsOpenAPIModels,
         :PowerOpenAPIModels,
         :PowerOperationsOpenAPIModels,
-        :PowerTimeSeriesOpenAPIModels,
     ],
 )
 Aqua.test_deps_compat(PowerNetworkMatrices)

--- a/test/test_arc_types_and_reductions.jl
+++ b/test/test_arc_types_and_reductions.jl
@@ -211,8 +211,15 @@ end
     )
     line_entries = PNM.get_name_to_arc_map(filtered, Line)
     @test !isempty(line_entries)
-    for k in keys(line_entries)
-        @test occursin("B", k)
+    # A composite entry is named for its arc, not its members, so the filter's effect is
+    # asserted on what it admitted rather than on how the entry is spelled. `any`, not `all`:
+    # `_entry_matches` indexes a homogeneous parallel group when *any* member qualifies, so a
+    # kept group can legitimately carry a member the predicate rejected. What must never
+    # happen is an entry admitted with no qualifying member at all.
+    nrd = PNM.get_network_reduction_data(ptdf)
+    for (arc, kind) in values(line_entries)
+        entry = getproperty(nrd, kind)[arc]
+        @test any(l -> occursin("B", PNM.get_name(l)), PNM.leaf_components(entry))
     end
     PNM.empty!(PNM.get_network_reduction_data(ptdf))
     @test isempty(PNM.get_network_reduction_data(ptdf))

--- a/test/test_network_reduction_data.jl
+++ b/test/test_network_reduction_data.jl
@@ -1,25 +1,27 @@
 @testset "Test parallel branch naming" begin
-    # An aggregate is named for its arc, not its members. The previous scheme -- longest
-    # common prefix of the member names -- was not injective and moved when membership did.
+    # An aggregate is named for its arc, not its members. The `double_circuit` suffix is
+    # retained -- it is what marks the row as a total across the members -- and only the
+    # stem changed: the longest common prefix of the member names was not injective and
+    # moved when membership did.
     l1 = Line(nothing)
     set_name!(l1, "A33-1")
     l2 = Line(nothing)
     set_name!(l2, "A33-2")
     bp = PNM.BranchesParallel{PSY.Line}(PSY.Line[l1, l2], (7, 9), PNM.EMPTY_TWO_PORT, false)
-    @test PNM.get_name(bp) == "parallel_7_9"
+    @test PNM.get_name(bp) == "7_9_double_circuit"
 
     # Member names no longer participate, so the two cases the old scheme distinguished --
     # shared prefix vs none -- now give the same name for the same arc.
     set_name!(l1, "B1")
     set_name!(l2, "C2")
     bp = PNM.BranchesParallel{PSY.Line}(PSY.Line[l1, l2], (7, 9), PNM.EMPTY_TWO_PORT, false)
-    @test PNM.get_name(bp) == "parallel_7_9"
+    @test PNM.get_name(bp) == "7_9_double_circuit"
 
     # Distinct arcs give distinct names, which the prefix scheme could not guarantee:
     # `La`/`Lb` and `Lc`/`Ld` both collapsed to `Ldouble_circuit`.
     other =
         PNM.BranchesParallel{PSY.Line}(PSY.Line[l1, l2], (3, 4), PNM.EMPTY_TWO_PORT, false)
-    @test PNM.get_name(other) == "parallel_3_4"
+    @test PNM.get_name(other) == "3_4_double_circuit"
     @test PNM.get_name(other) != PNM.get_name(bp)
 
     chain = PNM.BranchesSeries((11, 12))

--- a/test/test_network_reduction_data.jl
+++ b/test/test_network_reduction_data.jl
@@ -1,14 +1,27 @@
 @testset "Test parallel branch naming" begin
+    # An aggregate is named for its arc, not its members. The previous scheme -- longest
+    # common prefix of the member names -- was not injective and moved when membership did.
     l1 = Line(nothing)
     set_name!(l1, "A33-1")
     l2 = Line(nothing)
     set_name!(l2, "A33-2")
-    bp = PNM.BranchesParallel([l1, l2])
-    # Use common substring at start of name if possible:
-    @test PNM.get_name(bp) == "A33-double_circuit"
+    bp = PNM.BranchesParallel{PSY.Line}(PSY.Line[l1, l2], (7, 9), PNM.EMPTY_TWO_PORT, false)
+    @test PNM.get_name(bp) == "parallel_7_9"
+
+    # Member names no longer participate, so the two cases the old scheme distinguished --
+    # shared prefix vs none -- now give the same name for the same arc.
     set_name!(l1, "B1")
     set_name!(l2, "C2")
-    bp = PNM.BranchesParallel([l1, l2])
-    # Otherwise concatonate names:
-    @test PNM.get_name(bp) == "B1_C2_double_circuit"
+    bp = PNM.BranchesParallel{PSY.Line}(PSY.Line[l1, l2], (7, 9), PNM.EMPTY_TWO_PORT, false)
+    @test PNM.get_name(bp) == "parallel_7_9"
+
+    # Distinct arcs give distinct names, which the prefix scheme could not guarantee:
+    # `La`/`Lb` and `Lc`/`Ld` both collapsed to `Ldouble_circuit`.
+    other =
+        PNM.BranchesParallel{PSY.Line}(PSY.Line[l1, l2], (3, 4), PNM.EMPTY_TWO_PORT, false)
+    @test PNM.get_name(other) == "parallel_3_4"
+    @test PNM.get_name(other) != PNM.get_name(bp)
+
+    chain = PNM.BranchesSeries((11, 12))
+    @test PNM.get_name(chain) == "series_11_12"
 end


### PR DESCRIPTION
Names a reduced arc for the arc it occupies instead of for its members.

## The problem

A composite's name was the longest common prefix of its member names plus a suffix. That is not injective — `La ∥ Lb` and `Lc ∥ Ld` both produce `Ldouble_circuit` — so two groups could collide under one name. It also moved whenever membership did: adding a circuit to a corridor renamed it, and results stopped comparing across reduction settings.

The degenerate cases are worse than the collision. A prefix can be empty, or can be a bare bus number: POM's branch-rating fixture was reaching a group named `1double_circuit`.

## The change

Composites are named for their arc:

```julia
get_name(bp::AbstractBranchesParallel) = "$(bp.arc_key[1])_$(bp.arc_key[2])_double_circuit"
get_name(bs::BranchesSeries)           = "series_$(bs.arc_key[1])_$(bs.arc_key[2])"
```

`_composite_entries` already admits at most one composite per unordered bus pair, so `arc => name` is injective by construction.

**The `double_circuit` suffix is kept deliberately.** It is what tells a reader of results that the row is a total across the parallel members rather than one member's own flow. Only the stem changed. `_longest_starting_substring` is deleted.

Direct arcs keep their component's name, so the break lands only on names that were unstable anyway.

## Scope

Naming only — no change to which rows exist. A series chain still reports one row per segment under the segment's own component name, because each segment carries the arc's flow; a parallel group still reports once. `series_<from>_<to>` is the chain's identity in the catalog, never a reporting row, which is why the suffix question doesn't arise there.

## Breaking

Composite result keys change: `1-4-i_double_circuit` → `1_4_double_circuit`. Any fix to the old scheme breaks compatibility, since the old names were the defect.

## Testing

Suite 10,889,477. Formatter clean.

Also merges `psy6` and adds the two packages its OpenAPI-split commit put in `[deps]` to Aqua's stale-deps ignore list — pin-only entries, exactly as the comment above that list already describes. Without it `Aqua.test_stale_deps` fails on `psy6` itself and on anything branched from it; if `psy6` fixes this directly, expect a trivial conflict on those three lines.
