### PR TITLE
Let reverse indexing defer to the forward filter verdict

### DIFF
--- a/src/BranchCatalog.jl
+++ b/src/BranchCatalog.jl
@@ -322,6 +322,12 @@ function _index_reverse!(
 )
     for (member, arc) in source
         _entry_matches(member, predicate) || continue
+        # The forward pass owns `arcs`, and its verdict is the catalog's verdict. Reaching a
+        # different one here is not possible for a group matching on `any` -- acceptance
+        # there is a superset of its members' -- but `MixedBranchesParallel` matches on
+        # `all`, so a member can pass this predicate while its group did not. Redirecting it
+        # would name an entry that is not a row.
+        haskey(arcs, arc) || continue
         T = _get_segment_type(member)
         _store!(get!(() -> Dict{typeof(member), Tuple{Int, Int}}(), dest, T), member, arc)
         # The name comes from the table, not from a second call to `_entry_name`: one

--- a/test/test_branch_catalog.jl
+++ b/test/test_branch_catalog.jl
@@ -207,3 +207,62 @@ end
         @test haskey(line_rows, entry_name)
     end
 end
+
+@testset "BranchCatalog reverse indexing defers to the forward filter verdict" begin
+    # `_entry_matches` is not uniform across aggregates: `BranchesParallel` matches on
+    # `any`, `MixedBranchesParallel` on `all`. Forward indexing evaluates the predicate on
+    # the GROUP, reverse indexing on each MEMBER, so under `all` a member can pass while its
+    # group did not. The forward pass owns `arcs`; reverse must take its verdict rather than
+    # reach a different one, or it names an entry that is not a row.
+    sys = PSB.build_system(PSB.PSITestSystems, "c_sys14")
+    line = first(PSY.get_components(PSY.Line, sys))
+    xfmr = first(PSY.get_components(PSY.TwoWindingTransformer, sys))
+    arc = PSY.get_arc(line)
+
+    # Force the two onto one arc, which promotes them to a mixed parallel group.
+    nrd = PNM.NetworkReductionData()
+    PNM.add_to_branch_maps!(nrd, arc, line)
+    PNM.add_to_branch_maps!(nrd, arc, xfmr)
+    arc_tuple = PNM.get_arc_tuple(arc, nrd)
+    group = PNM.get_parallel_branch_map(nrd)[arc_tuple]
+    @test group isa PNM.MixedBranchesParallel
+
+    # Unfiltered: the group is a row and both members redirect to it. Without this the
+    # filtered assertions below would pass on an empty catalog.
+    base = PNM.BranchCatalog(nrd)
+    group_name = PNM.get_name(PNM.get_reduction_entry(base, arc_tuple))
+    @test PNM.get_name_to_arc_map(base, PSY.Line)[group_name] == arc_tuple
+    @test PNM.get_component_to_reduction_name_map(base, PSY.Line)[PSY.get_name(line)] ==
+          group_name
+    @test PNM.get_component_to_reduction_name_map(
+        base, PSY.TwoWindingTransformer,
+    )[PSY.get_name(xfmr)] == group_name
+
+    # Filtering out `Line` makes `all` reject the group while the transformer member still
+    # passes. This threw `KeyError: $(arc_tuple)` from the reverse pass.
+    filtered = PNM.BranchCatalog(nrd, (T, c) -> T !== PSY.Line)
+    @test filtered isa PNM.BranchCatalog
+
+    # The group is not a row anywhere...
+    for T in (PSY.Line, PSY.TwoWindingTransformer)
+        @test !haskey(PNM.get_name_to_arc_map(filtered, T), group_name)
+    end
+    # ...so no member may redirect to it, the transformer included even though it matched.
+    @test !haskey(
+        PNM.get_component_to_reduction_name_map(filtered, PSY.TwoWindingTransformer),
+        PSY.get_name(xfmr),
+    )
+    @test !haskey(
+        PNM.get_component_to_reduction_name_map(filtered, PSY.Line),
+        PSY.get_name(line),
+    )
+
+    # The general invariant the above is one instance of: a redirect that names no row is a
+    # dead end, which is what the pre-guard code wrote before it started throwing.
+    for (T, redirects) in PNM.get_component_to_reduction_name_map(filtered)
+        rows = PNM.get_name_to_arc_map(filtered, T)
+        for (_, entry_name) in redirects
+            @test haskey(rows, entry_name)
+        end
+    end
+end


### PR DESCRIPTION
Follow-up to #357, addressing Copilot's review comment on `_index_reverse!`. The finding is real; this is the guard plus a regression test.

## The bug

`_entry_matches` is not uniform across aggregates:

- `BranchesParallel` → `any(member matches)`
- `MixedBranchesParallel` → **`all(member matches)`**
- `BranchesSeries` → `all(segment matches)`


Suppose you have 2 components of different types in parallel (a `MixedBranchesParallel`), where one passes the filter and one doesn't.

Forward indexing goes thru the components asking about the **group**: under `all`, it skips the whole. As we do the forward index, we assemble `arcs`, so the arc for the parallel combined arc isn't in `arcs`.

Reverse indexing goes thru the components asking about the **members**: it skips the components that doesn't fit the filter, but then grabs the one that passes. It tries to get its name via `get_name(arcs[combined_arc])` -> `KeyError`.

Worth noting the old code was not correct here either. It did not throw, but it wrote a redirect into `component_to_entry` naming an entry that is not a row in `name_to_arc` — a dead end for any caller following it. The `KeyError` is that silent dangling pointer becoming loud.

## The fix

`arcs` is the forward pass's output, and the reverse pass consumes it as an input. A miss is a decision, not an accident:

```julia
haskey(arcs, arc) || continue
```

`BranchesSeries` shares the `all` asymmetry and is unaffected only because `_index_reverse_series!` takes no `arcs` and writes no redirect name — it would acquire the same defect the moment series arcs get the redirect treatment the other two have.

## Testing

New testset forces a `Line` and a `TwoWindingTransformer` onto one arc, which promotes them to a `MixedBranchesParallel`, then filters `Line` out. It asserts the catalog builds, the group is a row under neither type, neither member redirects to it — the transformer included, even though it matched — and the general invariant that every redirect names a row.

The unfiltered case is asserted first, so the filtered assertions cannot pass vacuously on an empty catalog. Verified by mutation: dropping the guard fails the testset with `KeyError: key (9, 14) not found`.

Suite 10,889,535. Formatter 0, docs 0.

## Base

Targets `lk/arc-derived-entry-names` rather than `psy6`, since that is where #357 landed and `psy6` does not carry `ArcEntry` yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017XUcz3ZFnWmRgwgrDjKsBb