### PR TITLE
Guard the component name index against the forward/reverse filter asymmetry

### DIFF
--- a/src/BranchCatalog.jl
+++ b/src/BranchCatalog.jl
@@ -412,11 +412,19 @@ a bare name.
 Built from the component-keyed maps rather than `name_to_arc`, which holds *entry* names: an
 aggregate's entry name is the group's, not any component's. Series-chain members are absent;
 name-based matrix indexing does not resolve them.
+
+Reads the predicate per component, so it inherits the forward/reverse asymmetry
+[`_index_reverse!`](@ref) guards against: a `MixedBranchesParallel` member can match where
+its group did not. It resolves it the same way -- `arcs` is the forward pass's verdict, and
+an arc absent from it has no entry to scale, so the name does not resolve. Without the
+guard `get_branch_multiplier` walks name -> arc -> [`get_reduction_entry`](@ref) and throws
+a bare `KeyError` instead of its own diagnosis.
 """
-function _build_component_name_index(nrd::NetworkReductionData, predicate)
+function _build_component_name_index(nrd::NetworkReductionData, arcs::ARC_TABLE, predicate)
     index = COMPONENT_NAME_INDEX()
     for (arc, entry) in nrd.direct_branch_map
         _entry_matches(entry, predicate) || continue
+        haskey(arcs, arc) || continue
         push!(
             _name_candidates(index, get_name(entry)),
             (typeof(entry), arc),
@@ -424,6 +432,7 @@ function _build_component_name_index(nrd::NetworkReductionData, predicate)
     end
     for (member, arc) in nrd.reverse_parallel_branch_map
         _entry_matches(member, predicate) || continue
+        haskey(arcs, arc) || continue
         push!(
             _name_candidates(index, get_name(member)),
             (typeof(member), arc),
@@ -549,6 +558,6 @@ function BranchCatalog(nrd::NetworkReductionData, predicate; validate::Bool = fa
         maps,
         name_to_arc,
         component_to_entry,
-        _build_component_name_index(nrd, predicate),
+        _build_component_name_index(nrd, arcs, predicate),
     )
 end

--- a/test/test_branch_catalog.jl
+++ b/test/test_branch_catalog.jl
@@ -265,4 +265,24 @@ end
             @test haskey(rows, entry_name)
         end
     end
+
+    # `_build_component_name_index` is a third pass reading the predicate per component, so
+    # it leaks the same asymmetry by its own route: it backs `get_branch_multiplier`, whose
+    # name -> arc -> entry walk ends in `get_reduction_entry`.
+    index = PNM.get_component_name_index(filtered)
+    @test !haskey(index, PSY.get_name(xfmr))
+    @test !haskey(index, PSY.get_name(line))
+    # Every arc the name index offers must have an entry to resolve to.
+    for (_, candidates) in index
+        for (_, candidate_arc) in candidates
+            @test PNM.get_reduction_entry(filtered, candidate_arc) isa PSY.ACTransmission
+        end
+    end
+
+    # Unfiltered, the transformer does resolve -- so the assertions above are the guard
+    # working, not the fixture failing to build a name index at all.
+    base_index = PNM.get_component_name_index(base)
+    @test haskey(base_index, PSY.get_name(xfmr))
+    @test only(base_index[PSY.get_name(xfmr)]) == (PSY.TwoWindingTransformer, arc_tuple)
+    @test PNM.get_reduction_entry(base, arc_tuple) === group
 end


### PR DESCRIPTION
Follow-up to #360, which merged before this commit was pushed. Addresses Copilot's second review comment on that PR — it found a route the first guard structurally could not cover.

## The gap

`_index_reverse!` was not the only pass reading the predicate per component. `_build_component_name_index` is a third pass over the reduction maps, doing the same thing, and it was called `(nrd, predicate)` — it never saw `arcs`, so guarding `_index_reverse!` left it untouched.

Reproduced on #360's own fixture (a `Line` and a `TwoWindingTransformer` forced onto one arc, then `Line` filtered out):

```
arcs table keys: Tuple{Int64, Int64}[]          # forward rejected the mixed group
xfmr in component_name_index: true
  -> [(TwoWindingTransformer, (9, 14))]         # name index kept it anyway
THREW: KeyError: key (9, 14) not found          # get_reduction_entry on that arc
```

This is the worse of the two failure modes. The original `KeyError` fired during construction; this one fires from `get_branch_multiplier` — name → arc → `get_reduction_entry` — on a catalog that built cleanly, so it surfaces on the public API at an arbitrary later point.

## The fix

Thread `arcs` in and guard both loops. `arcs` is the forward pass's verdict; an arc absent from it has no entry to scale, so the name does not resolve and `get_branch_multiplier` reaches its own diagnosis ("resolves to no directly-indexed or parallel-group branch") instead of a bare `KeyError`.

The direct-map loop was already symmetric with the forward pass — both ask the predicate about the same entry — but it is guarded too rather than left as a fact someone has to re-derive before touching this function.

## Testing

Extends #360's testset: the transformer name is absent from the filtered name index, every arc the index does offer resolves to an entry, and the unfiltered catalog still resolves the transformer to the group — so the filtered assertions cannot pass on an index that merely failed to build. Mutation-checked: dropping the two guards fails it with one failure plus the `KeyError`.

Suite 10,889,540. Formatter 0, docs 0.

## Worth a separate look

Three passes now apply the same predicate at three different granularities, and there is no structural reason a fourth would not repeat the mistake — this PR exists because the second one was missed. Evaluating the filter once and having every pass read that verdict would make the class of bug unrepresentable; `arcs` is already most of the way to being that. Not folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017XUcz3ZFnWmRgwgrDjKsBb